### PR TITLE
Use in-memory auth token rather than saving to disk

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,8 @@
+linters:
+  flake8:
+    ignore: 'E501'
+    max-line-length: 120
+    # fixer: true
+  pep8:
+    max-line-length: 120
+    # fixer: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include uit/data/DoD_CAs.pem

--- a/tests/test_uit.py
+++ b/tests/test_uit.py
@@ -21,30 +21,6 @@ class TestUIT(unittest.TestCase):
         # call the method
         self.assertEqual('test_token', client.load_token())
 
-    @mock.patch('builtins.open')
-    @mock.patch('yaml.load')
-    def test_load_token_config(self, mock_load, __):
-        from datetime import datetime
-        from datetime import timedelta
-        client = Client(client_id='C001', client_secret='S001')
-        mock_config = mock.MagicMock()
-        mock_load.return_value = mock_config
-        test_dt = datetime.now() + timedelta(days=1)
-        test_dt_converted = test_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
-        mock_config.get.return_value = [{'access_token_expires_on': test_dt_converted, 'access_token': 'foo'}]
-        # call the method
-        self.assertEqual('foo', client.load_token())
-
-    @mock.patch('builtins.open')
-    @mock.patch('yaml.load')
-    def test_load_token_config_none(self, mock_load, __):
-        client = Client(client_id='C001', client_secret='S001')
-        mock_config = mock.MagicMock()
-        mock_load.return_value = mock_config
-        mock_config.get.return_value = None
-        # call the method
-        self.assertIsNone(client.load_token())
-
     @mock.patch('uit.uit.Client.call')
     @mock.patch('uit.uit.Client.put_file')
     def test_submit(self, _, mock_call):

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -166,7 +166,7 @@ class Client:
         """Generate Authorization URL with UIT Server.
 
         Example:
-        https://uit.erdc.dren.mil/uapi/authorize?client_id=e01012b4-ab2c-4d95-83b3-26600a13ee0c&scope=UIT&state=2342342
+        https://www.uitplus.hpc.mil/uapi/authorize?client_id=e01012b4-ab2c-4d95-83b3-26600a13ee0c&scope=UIT&state=2342342
 
         Returns:
             str: Authorization URL.
@@ -527,7 +527,7 @@ def start_server(auth_func, config_file):
 
         html_template = """
         <!doctype html>
-        <title>UIT Authentication Succeeded</title>
+        <title styles="margin: auto;">UIT Authentication Succeeded</title>
         """
         shutdown_server()
         return render_template_string(html_template)


### PR DESCRIPTION
- per Glover, it is against security policy to save the access token to disk. This PR uses an in-memory token.

- Also uses safe_yaml and bundles DoD.pm cert file correctly using MANIFEST.in