### PR TITLE
This adds LoadingSpinners to the Select and Browse buttons using js_on_click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 
 # ViM Files
 *.swp
+
+# VS Code Projects
+.vscode

--- a/uit/gui_tools/connect.py
+++ b/uit/gui_tools/connect.py
@@ -79,12 +79,13 @@ class HpcConnect(param.Parameterized):
 
     @param.depends('system', watch=True)
     def update_node_options(self):
-        options = self.uit_client.login_nodes[self.system]
-        self.param.exclude_nodes.objects = options
-        options = options.copy()
-        options.insert(0, None)
-        self.param.login_node.objects = options
-        self.param.login_node.names = {'Random': None}
+        if self.uit_client.login_nodes:
+            options = self.uit_client.login_nodes[self.system]
+            self.param.exclude_nodes.objects = options
+            options = options.copy()
+            options.insert(0, None)
+            self.param.login_node.objects = options
+            self.param.login_node.names = {'Random': None}
 
     @param.depends('login_node', watch=True)
     def update_exclude_nodes_visibility(self):

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -514,7 +514,7 @@ class SelectFile(param.Parameterized):
         )[0]
         browse_toggle.js_on_click(args={'btn': browse_toggle, 'spn': spn}, code='btn.visible=true; spn.width=50;')
 
-        input_row = pn.Row(
+        filepath_row = pn.Row(
             pn.Param(
                 self,
                 parameters=['file_path'],
@@ -529,11 +529,10 @@ class SelectFile(param.Parameterized):
             ),
             browse_toggle, spn
         )
-
         self.param.file_path.label = self.title
 
         return pn.Column(
-            input_row,
+            filepath_row,
             pn.pane.HTML(f'<span style="font-style: italic;">{self.help_text}</span>'),
             self.file_browser_panel,
             width_policy='max'

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -257,16 +257,28 @@ class FileBrowser(param.Parameterized):
 
     @property
     def panel(self):
-        return pn.Column(
+        spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=0)
+        select_btn = pn.Param(
+            self.param.callback,
+            widgets={'callback': {'width': 100, 'button_type': 'success'}}
+        )[0]
+        select_btn.js_on_click(args={'btn': select_btn, 'spn': spn}, code='btn.visible=true; spn.width=50;')
+
+        browser_bar = pn.Row(
             pn.Param(
                 self,
-                parameters=self.controls + ['path_text', 'callback'],
+                parameters=self.controls + ['path_text'],
                 widgets=self.control_styles,
                 default_layout=pn.Row,
                 width_policy='max',
                 show_name=False,
                 margin=0,
             ),
+            select_btn, spn
+        )
+
+        return pn.Column(
+            browser_bar,
             self.param.show_hidden,
             pn.Param(self.param.file_listing, widgets={'file_listing': {'height': 200}}, width_policy='max'),
             width_policy='max',
@@ -467,25 +479,50 @@ class SelectFile(param.Parameterized):
             self.file_browser.init()
             return self.file_browser.panel
 
-    def input_row(self):
-        return pn.Param(
-            self,
-            parameters=['file_path', 'browse_toggle'],
-            widgets={
-                'file_path': {'width_policy': 'max', 'show_name': False},
-                'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
-            },
-            default_layout=pn.Row,
-            show_name=False,
-            width_policy='max',
-            margin=0,
-        )
+    # def input_row(self):
+    #     return pn.Param(
+    #         self,
+    #         parameters=['file_path'],
+    #         widgets={
+    #             'file_path': {'width_policy': 'max', 'show_name': False},
+    #             # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
+    #         },
+    #         default_layout=pn.Row,
+    #         show_name=False,
+    #         width_policy='max',
+    #         margin=0,
+    #     )
 
     @property
     def panel(self):
+        spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=0)
+
+        browse_toggle = pn.Param(
+            self.param.browse_toggle,
+            widgets={'browse_toggle': {'width': 100, 'button_type': 'primary'}}
+        )[0]
+        browse_toggle.js_on_click(args={'btn': browse_toggle, 'spn': spn}, code='btn.visible=true; spn.width=50;')
+
+        input_row = pn.Row(
+            pn.Param(
+                self,
+                parameters=['file_path'],
+                widgets={
+                    'file_path': {'width_policy': 'max', 'show_name': False},
+                    # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
+                },
+                default_layout=pn.Row,
+                show_name=False,
+                width_policy='max',
+                margin=0,
+            ),
+            browse_toggle, spn
+        )
+
         self.param.file_path.label = self.title
+
         return pn.Column(
-            self.input_row,
+            input_row,
             pn.pane.HTML(f'<span style="font-style: italic;">{self.help_text}</span>'),
             self.file_browser_panel,
             width_policy='max'

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 import param
 import panel as pn
-import panel.models.ace  # noqa: F401
+# import panel.models.ace  # noqa: F401
 
 from uit.uit import Client
 
@@ -591,6 +591,8 @@ class FileViewer(param.Parameterized):
 
     @param.depends('update_btn')
     def view(self):
+        import panel.models.ace  # noqa: F401
+
         file_path = self.file_select.file_path
         return pn.Column(
             pn.widgets.TextInput(value=file_path, disabled=True),

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -284,24 +284,21 @@ class FileBrowser(param.Parameterized):
         )[0]
         select_btn.on_click(self.toggle_loading)
 
-        browser_bar = pn.Row(
-            pn.Param(
-                self,
-                parameters=self.controls + ['path_text'],
-                widgets=self.control_styles,
-                default_layout=pn.Row,
-                width_policy='max',
-                show_name=False,
-                margin=0,
-            ),
-            select_btn,
-        )
-
         return pn.Column(
-            browser_bar,
+            pn.Row(
+                pn.Param(
+                    self,
+                    parameters=self.controls + ['path_text'],
+                    widgets=self.control_styles,
+                    default_layout=pn.Row,
+                    width_policy='max',
+                    show_name=False,
+                    margin=0,
+                ),
+            select_btn, self.loading,
+            ),
             self.param.show_hidden,
-            self.param.file_listing,
-            self.loading,
+            pn.Param(self.param.file_listing, widgets={'file_listing': {'height': 200}}, width_policy='max'),
             width_policy='max',
             margin=0,
         )

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -510,7 +510,7 @@ class SelectFile(param.Parameterized):
 
         browse_toggle = pn.Param(
             self.param.browse_toggle,
-            widgets={'browse_toggle': {'width': 100, 'button_type': 'primary'}}
+            widgets={'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}}
         )[0]
         browse_toggle.js_on_click(args={'btn': browse_toggle, 'spn': spn}, code='btn.visible=true; spn.width=50;')
 
@@ -520,7 +520,6 @@ class SelectFile(param.Parameterized):
                 parameters=['file_path'],
                 widgets={
                     'file_path': {'width_policy': 'max', 'show_name': False},
-                    # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
                 },
                 default_layout=pn.Row,
                 show_name=False,

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 import param
 import panel as pn
+import panel.models.ace  # noqa: F401
 
 from uit.uit import Client
 
@@ -256,16 +257,28 @@ class FileBrowser(param.Parameterized):
 
     @property
     def panel(self):
-        return pn.Column(
+        spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=0)
+        select_btn = pn.Param(
+            self.param.callback,
+            widgets={'callback': {'width': 100, 'button_type': 'success'}}
+        )[0]
+        select_btn.js_on_click(args={'btn': select_btn, 'spn': spn}, code='btn.visible=true; spn.width=50;')
+
+        browser_bar = pn.Row(
             pn.Param(
                 self,
-                parameters=self.controls + ['path_text', 'callback'],
+                parameters=self.controls + ['path_text'],
                 widgets=self.control_styles,
                 default_layout=pn.Row,
                 width_policy='max',
                 show_name=False,
                 margin=0,
             ),
+            select_btn, spn
+        )
+
+        return pn.Column(
+            browser_bar,
             self.param.show_hidden,
             pn.Param(self.param.file_listing, widgets={'file_listing': {'height': 200}}, width_policy='max'),
             width_policy='max',
@@ -466,25 +479,50 @@ class SelectFile(param.Parameterized):
             self.file_browser.init()
             return self.file_browser.panel
 
-    def input_row(self):
-        return pn.Param(
-            self,
-            parameters=['file_path', 'browse_toggle'],
-            widgets={
-                'file_path': {'width_policy': 'max', 'show_name': False},
-                'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
-            },
-            default_layout=pn.Row,
-            show_name=False,
-            width_policy='max',
-            margin=0,
-        )
+    # def input_row(self):
+    #     return pn.Param(
+    #         self,
+    #         parameters=['file_path'],
+    #         widgets={
+    #             'file_path': {'width_policy': 'max', 'show_name': False},
+    #             # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
+    #         },
+    #         default_layout=pn.Row,
+    #         show_name=False,
+    #         width_policy='max',
+    #         margin=0,
+    #     )
 
     @property
     def panel(self):
+        spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=0)
+
+        browse_toggle = pn.Param(
+            self.param.browse_toggle,
+            widgets={'browse_toggle': {'width': 100, 'button_type': 'primary'}}
+        )[0]
+        browse_toggle.js_on_click(args={'btn': browse_toggle, 'spn': spn}, code='btn.visible=true; spn.width=50;')
+
+        input_row = pn.Row(
+            pn.Param(
+                self,
+                parameters=['file_path'],
+                widgets={
+                    'file_path': {'width_policy': 'max', 'show_name': False},
+                    # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
+                },
+                default_layout=pn.Row,
+                show_name=False,
+                width_policy='max',
+                margin=0,
+            ),
+            browse_toggle, spn
+        )
+
         self.param.file_path.label = self.title
+
         return pn.Column(
-            self.input_row,
+            input_row,
             pn.pane.HTML(f'<span style="font-style: italic;">{self.help_text}</span>'),
             self.file_browser_panel,
             width_policy='max'
@@ -521,7 +559,8 @@ class FileViewer(param.Parameterized):
             try:
                 self.file_contents = self.uit_client.call(f'{self.cmd} -n {self.n} {self.file_select.file_path}')
             except Exception as e:
-                #                 self.file_contents = f'ERROR!: {e}'
+                log.debug(e)
+                # self.file_contents = f'ERROR!: {e}'
                 self.file_contents = ''
             self.param.trigger('update_btn')
 

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -504,20 +504,6 @@ class SelectFile(param.Parameterized):
             self.file_browser.init()
             return self.file_browser.panel
 
-    # def input_row(self):
-    #     return pn.Param(
-    #         self,
-    #         parameters=['file_path'],
-    #         widgets={
-    #             'file_path': {'width_policy': 'max', 'show_name': False},
-    #             # 'browse_toggle': {'button_type': 'primary', 'width': 100, 'align': 'end'}
-    #         },
-    #         default_layout=pn.Row,
-    #         show_name=False,
-    #         width_policy='max',
-    #         margin=0,
-    #     )
-
     @property
     def panel(self):
         spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=0)

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -276,11 +276,12 @@ class FileBrowser(param.Parameterized):
             ),
             select_btn, spn
         )
+        file_listing_wgt = pn.Param(self.param.file_listing, widgets={'file_listing': {'height': 200}}, width_policy='max')
 
         return pn.Column(
             browser_bar,
             self.param.show_hidden,
-            pn.Param(self.param.file_listing, widgets={'file_listing': {'height': 200}}, width_policy='max'),
+            file_listing_wgt,
             width_policy='max',
             margin=0,
         )

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -216,7 +216,7 @@ class FileBrowser(param.Parameterized):
     file_listing = param.ListSelector(default=[], label='', precedence=0.5)
     patterns = param.List(precedence=-1, default=['*'])
     show_hidden = param.Boolean(default=False, label='Show Hidden Files', precedence=0.35)
-    spn2 = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=50)
+    spn = pn.widgets.indicators.LoadingSpinner(value=True, color='primary', aspect_ratio=1, width=50)
     show_loading = param.Boolean(default=False)
 
 
@@ -271,7 +271,7 @@ class FileBrowser(param.Parameterized):
                 if str(self.path_text).endswith(str(self.file_listing[0])):
                     self.show_loading = False
         if self.show_loading:
-            return pn.Column(self.spn2)
+            return pn.Column(self.spn)
 
     def toggle_loading(self, event=None):
         self.show_loading = True


### PR DESCRIPTION
@sdc50 I marked this pull request as not ready for review, because I still need to figure out how to hide the spinners after 3-4 seconds. We didn't have this issue with the Continue button loading spinners, because we navigated away from the page where they were loaded.