### PR TITLE
Ignore qdel warning

### DIFF
--- a/uit/job.py
+++ b/uit/job.py
@@ -155,8 +155,11 @@ class PbsJob:
             self.client.call(command=f'{cmd} {self.job_id}')
             return True
         except Exception as e:
-            if cmd == 'qdel' and 'qdel: Job has finished' in str(e):
-                # qdel exits with a returncode of 35 if it is run on a job that has already finished
+            if cmd == 'qdel' and ('qdel: Job has finished' in str(e) or 'qdel: Unknown Job Id' in str(e)):
+                # qdel exits with rc=35 and 'qdel: Job has finished' if it is run on a job that has already finished
+                # qdel exits with rc=153 and 'qdel: Unknown Job Id' if the job is too old
+                # This basically tests if the HPC is working well enough to send 'rm -rf' commands next
+                # This should not fail to delete from jobs_table when PBS no longer remembers the job
                 return True
             else:
                 logger.exception(f"Error when running '{cmd}': {e}")

--- a/uit/job.py
+++ b/uit/job.py
@@ -152,7 +152,7 @@ class PbsJob:
 
     def _execute(self, cmd):
         try:
-            self.client.call(command=f'{cmd} {self.job_id}', working_dir=self.working_dir)
+            self.client.call(command=f'{cmd} {self.job_id}')
             return True
         except Exception as e:
             logger.exception(e)

--- a/uit/job.py
+++ b/uit/job.py
@@ -155,8 +155,12 @@ class PbsJob:
             self.client.call(command=f'{cmd} {self.job_id}')
             return True
         except Exception as e:
-            logger.exception(e)
-            return False
+            if cmd == 'qdel' and 'qdel: Job has finished' in str(e):
+                # qdel exits with a returncode of 35 if it is run on a job that has already finished
+                return True
+            else:
+                logger.exception(f"Error when running '{cmd}': {e}")
+                return False
 
     def _transfer_files(self):
         # Transfer any files listed in transfer_input_files to working_dir on supercomputer


### PR DESCRIPTION
CHW-232 Do not delete job when host cannot be reached
This change ignores the exception when qdel is ran against a completed job.
It also avoids an error when deleting an archived job. If the main job was already deleted, it would try to run qdel from the working_dir that was already deleted. working_dir shouldn't be needed when running PBS commands.