### PR TITLE
Add debug logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ There are three ways that you can configure PyUIT to use the ``Client ID`` and t
 
 2. Set the ``UIT_ID`` and ``UIT_SECRET`` environmental variables
 
-If the ``client_id`` or the ``client_secrete`` are not passed into the ``Client`` when it is instantiated, then it will next look for those values from environmental variables. On UNIX systems you can set the environmental variables as follows::
+If the ``client_id`` or the ``client_secret`` are not passed into the ``Client`` when it is instantiated, then it will next look for those values from environmental variables. On UNIX systems you can set the environmental variables as follows::
 
   export UIT_ID="<YOUR_CLIENT_ID>"
   export UIT_SECRET="<YOUR_CLIENT_SECRET>"

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-ignore = 'E501'
+ignore = E501
 max-line-length = 120
 exclude = .git,build,dist,__pycache__,.eggs,*.egg-info,venv

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -417,29 +417,35 @@ class HpcPath(Path, PurePosixPath):
         if not self.is_absolute():
             self._str = str(self.uit_client.HOME / self)
         try:
-            ls = self.parse_list_dir(self.parent.as_posix())
+            ls_text = self.uit_client.call(f'ls -ldL {self.as_posix()}')  # -L dereferences symlinks
         except UITError:
-            raise ValueError(f'Invalid file path {self.parent.as_posix()}')
-        if 'dirs' not in ls:  # then ls is invalid
-            raise ValueError(f'Invalid file path {self.parent.as_posix()}')
+            raise ValueError(f'Invalid file path {self.as_posix()}')
         self._is_dir = False
         self._is_file = False
         self._ls = None
 
-        # compare names instead of full path to handle symbolic links
-        if self.name in (d['name'] for d in ls['dirs']):
+        if self.name == '':
+            # If I don't have a name, don't consider myself a directory or file.
+            # Without this, the first directory chosen would break with a grayed-out file listing.
+            # It has something to do with loading the home directory for the first time.
+            return
+
+        if ls_text.startswith('d'):
             self._is_dir = True
             self._ls = self.uit_client.list_dir(self.as_posix())
             if 'error' in self._ls:
+                # Try our own 'ls -l' if UIT+ returns any error, which happens if there is a broken symlink
                 self._ls = self.parse_list_dir(self.as_posix())
-        elif self.name in (f['name'] for f in ls['files']):
+        elif ls_text.startswith('-'):
             self._is_file = True
             self._ls = ''
+        else:
+            raise ValueError(f'Invalid file path {self.as_posix()}')
 
     def parse_list_dir(self, base_path):
         TYPES = {'d': 'dir', '-': 'file', 'l': 'link', 's': 'dir'}
         parsed_ls = {'path': base_path, 'dirs': [], 'files': [], 'links': []}
-        ls = self.uit_client.call(f'ls -l {base_path}', full_response=True)
+        ls = self.uit_client.call(f'ls -lL {base_path}', full_response=True)
         for f in ls['stdout'].splitlines()[1:]:
             parts = f.split()
 

--- a/uit/job.py
+++ b/uit/job.py
@@ -152,11 +152,18 @@ class PbsJob:
 
     def _execute(self, cmd):
         try:
-            self.client.call(command=f'{cmd} {self.job_id}', working_dir=self.working_dir)
+            self.client.call(command=f'{cmd} {self.job_id}')
             return True
         except Exception as e:
-            logger.exception(e)
-            return False
+            if cmd == 'qdel' and ('qdel: Job has finished' in str(e) or 'qdel: Unknown Job Id' in str(e)):
+                # qdel exits with rc=35 and 'qdel: Job has finished' if it is run on a job that has already finished
+                # qdel exits with rc=153 and 'qdel: Unknown Job Id' if the job is too old
+                # This basically tests if the HPC is working well enough to send 'rm -rf' commands next
+                # This should not fail to delete from jobs_table when PBS no longer remembers the job
+                return True
+            else:
+                logger.exception(f"Error when running '{cmd}': {e}")
+                return False
 
     def _transfer_files(self):
         # Transfer any files listed in transfer_input_files to working_dir on supercomputer

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -780,7 +780,7 @@ class Client:
             nice_stdout = "\n  stdout="
             if len(resp.get('stdout')) > 500:
                 nice_stdout += "'" + resp.get('stdout')[:500].replace('\n', '\\n') + \
-                              f"'  <len:{len(resp.get('stdout'))}>"
+                               f"'  <len:{len(resp.get('stdout'))}>"
             else:
                 nice_stdout += "'" + resp.get('stdout').replace('\n', '\\n') + "'"
 
@@ -789,7 +789,7 @@ class Client:
             nice_stderr = "\n  stderr="
             if len(resp.get('stderr')) > 500:
                 nice_stderr += "'" + resp.get('stderr')[:500].replace('\n', '\\n') + \
-                              f"'  <len:{len(resp.get('stderr'))}>"
+                               f"'  <len:{len(resp.get('stderr'))}>"
             else:
                 nice_stderr += "'" + resp.get('stderr').replace('\n', '\\n') + "'"
 

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -15,6 +15,7 @@ from urllib.parse import urljoin, urlencode  # noqa: F401
 
 import dodcerts
 import requests
+import simplejson.errors
 import yaml
 from flask import Flask, request, render_template_string
 from werkzeug.serving import make_server
@@ -765,9 +766,9 @@ class Client:
 
         debug_header = f" {FG_RED}time={time_text}{ALL_OFF}    node={self.login_node}"
 
-        if len(local_vars['r'].text) > 0:
+        try:
             resp = local_vars['r'].json()
-        else:
+        except simplejson.errors.JSONDecodeError:
             resp = {}
 
         if resp.get('exitcode') is not None:

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -796,7 +796,7 @@ class Client:
         # Show only relevant function calls and ignore standard library
         only_show_stacktrace = ['pyuit',
                                 'helios',
-                                'tethys_app',
+                                'tethysapp',
                                 'uit_plus',
                                 'kestrel',
                                 'galaxy',
@@ -823,7 +823,9 @@ class Client:
                     nice_trace += f"\n    {i}: {trimmed_filename}:" + \
                                   f"{stacktrace[i].lineno} {stacktrace[i].name}()" + \
                                   f"    {stacktrace[i].line.encode('ascii', 'backslashreplace').decode('ascii')}"
-            # This uses encode('ascii') because logging did not like the unicode characters in file browser buttons
+                    # This uses encode('ascii') because the logging module did not like the unicode characters in
+                    # file browser buttons
+                    break
 
         return f"{debug_header}{nice_stdout}{nice_stderr}{nice_trace}"
 


### PR DESCRIPTION
CHW-428
This change adds logging for several UIT+ calls:
- For get_userinfo(), it adds only an INFO log line
- For call(), get_file(), put_file(), and list_directory(), it adds one INFO line and many DEBUG lines.
  - The INFO line for call() will show the shell command in cyan text and working directory
  - The INFO line for get_file() and put_file() will show the remote file and local file
  - The INFO line for list_directory() will show the remote directory
  - The DEBUG lines for these four functions will show:
    - Duration of the request in red text
    - Login node
    - Return code of the shell command
    - HPCMP username
    - if they are not empty, stdout and stderr will show up to 500 characters in each, and all line breaks are shown as \n
    - A brief stacktrace that only shows our codebases and ignores python standard library, bokeh, panel, param, django, tethys, etc.

Most of the debug code will not be executed unless logging has DEBUG enabled. I had one instance where it tried to send the unicode icons in the File Browser to logging, and the logging module crashed on it. I found a workaround for that specific case, but I never want to see anything like that happen on a prod server, especially if the prod server is not logging this information. 

Here is an example of the debug output:
![uit-debug](https://user-images.githubusercontent.com/14322382/224152747-04d8bd7a-8404-45fd-ae39-5ece257e926c.png)
To get pyuit debug logging, you will need to modify your ~/.tethys/<conda_env>/portal_config.yml with at least this much yaml:
```
settings:
  LOGGING:
    loggers:
      uit:
        handlers:
          - console_verbose
        level: DEBUG 
```
If you want less logging, set the level from DEBUG to INFO.

This only shows stacktrace lines from 'pyuit' be default, which only works in a dev environment. To show lines from your codebases, add these lines to a config file named ~/.uit:
```
debug_stacktrace_allowlist:
  - uit
  - your_codebase_dir
```
To see debug logging in Jupyter Lab, run this code to show debug output:
```
import logging
handler = logging.StreamHandler()
formatter = logging.Formatter('%(asctime)s %(levelname)s:%(name)s:%(message)s')
handler.setFormatter(formatter)
logger = logging.getLogger('uit')
logger.addHandler(handler)
logger.setLevel('DEBUG') 
```