### PR TITLE
Improve retries when connecting

### DIFF
--- a/uit/gui_tools/connect.py
+++ b/uit/gui_tools/connect.py
@@ -6,7 +6,7 @@ import panel as pn
 from .utils import make_bk_label
 
 from ..uit import Client, HPC_SYSTEMS
-from ..exceptions import MaxRetriesError
+from ..exceptions import UITError, MaxRetriesError
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class HpcConnect(param.Parameterized):
                 exclude_login_nodes=self.exclude_nodes,
                 retry_on_failure=retry,
             )
-        except MaxRetriesError as e:
+        except (UITError, MaxRetriesError) as e:
             logger.exception(e)
             self.exclude_nodes.append(self.uit_client.login_node)
             self.disconnect()

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -284,7 +284,9 @@ class Client:
             self.connected = False
             msg = f'Error while connecting to node {login_node}: {e}'
             logger.info(msg)
-            if retry_on_failure and num_retries > 0:
+            if retry_on_failure is False:
+                raise UITError(msg)
+            elif retry_on_failure and num_retries > 0:
                 logger.debug(f'Retrying connection {num_retries} more time(s)')
                 num_retries -= 1
                 exclude_login_nodes = list(exclude_login_nodes) + [login_node]

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -290,7 +290,7 @@ class Client:
 
         try:
             # working_dir='.' ends up being the location for UIT+ scripts, not the user's home directory
-            self._call(':', working_dir='.')
+            self._call(':', working_dir='.', timeout=20)
         except UITError as e:
             self.connected = False
             msg = f'Error while connecting to node {login_node}: {e}'
@@ -414,24 +414,24 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def call(self, command, working_dir=None, full_response=False, raise_on_error=True):
+    def call(self, command, working_dir=None, full_response=False, raise_on_error=True, timeout=120):
         """Execute commands on the HPC via the exec endpoint.
 
         Args:
             command (str): The command to run.
             working_dir (str, optional, default=None): Working directory from which to run the command.
-                If None the users $HOME directory will be used
-            full_response(bool, default=False):
-                If True return the full JSON response from the UIT+ server.
-            raise_on_error(bool, default=True):
-                If True then an error is raised if the call is not successful.
+                If None, the users $HOME directory will be used.
+            full_response (bool, optional, default=False): If True return the full JSON response from the UIT+ server.
+            raise_on_error (bool, optional, default=True): If True then an exception is raised if the command fails.
+            timeout (int, optional, default=120): Number of seconds to limit the duration of the requests.post() call.
 
         Returns:
             str: stdout from the command.
         """
-        return self._call(command, working_dir=working_dir, full_response=full_response, raise_on_error=raise_on_error)
+        return self._call(command, working_dir=working_dir, full_response=full_response,
+                          raise_on_error=raise_on_error, timeout=timeout)
 
-    def _call(self, command, working_dir=None, full_response=False, raise_on_error=True):
+    def _call(self, command, working_dir=None, full_response=False, raise_on_error=True, timeout=120):
         """Internal call function to avoid the 3 retries from @robust()"""
         # Need to do this manually to prevent recursive loop when resolving self.home
         working_dir = working_dir or self.HOME
@@ -443,7 +443,14 @@ class Client:
         data = {'options': json.dumps(data, default=encode_pure_posix_path)}
         logger.info(f"call command='{FG_CYAN}{command}{ALL_OFF}'    {working_dir=}")
         debug_start_time = time.perf_counter()
-        r = requests.post(urljoin(self._uit_url, 'exec'), headers=self.headers, data=data, verify=self.ca_file)
+        try:
+            r = requests.post(urljoin(self._uit_url, 'exec'), headers=self.headers, data=data, verify=self.ca_file,
+                              timeout=timeout)
+        except requests.Timeout as e:
+            if raise_on_error:
+                raise UITError('Request Timeout')
+            else:
+                return 'ERROR! Request Timeout'
         logger.debug(self._debug_uit(locals()))
 
         if r.status_code == 504:
@@ -465,12 +472,14 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def put_file(self, local_path, remote_path=None):
+    def put_file(self, local_path, remote_path=None, timeout=20):
         """Put files on the HPC via the putfile endpoint.
 
         Args:
             local_path (str): Local file to upload.
-            remote_path (str): Remote file to upload to.
+            remote_path (str): Remote file to upload to. Do not use shell shortcuts like ~ or variables like $HOME.
+            timeout(int): Number of seconds to limit the duration of the requests.post() call,
+                although ongoing data transfer will not trigger a timeout.
 
         Returns:
             str: API response as json
@@ -484,19 +493,25 @@ class Client:
         files = {'file': local_path.open(mode='rb')}
         logger.info(f"put_file {local_path=}    {remote_path=}")
         debug_start_time = time.perf_counter()
-        r = requests.post(urljoin(self._uit_url, 'putfile'), headers=self.headers, data=data, files=files,
-                          verify=self.ca_file)
+        try:
+            r = requests.post(urljoin(self._uit_url, 'putfile'), headers=self.headers, data=data, files=files,
+                              verify=self.ca_file, timeout=timeout)
+        except requests.Timeout as e:
+            raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
+
         return r.json()
 
     @_ensure_connected
     @robust()
-    def get_file(self, remote_path, local_path=None):
+    def get_file(self, remote_path, local_path=None, timeout=20):
         """Get a file from the HPC via the getfile endpoint.
 
         Args:
             remote_path (str): Remote file to download.
             local_path (str): local file to download to.
+            timeout(int): Number of seconds to limit the duration of the requests.post() call,
+                although ongoing data transfer will not trigger a timeout.
 
         Returns:
             Path: local_path
@@ -506,11 +521,15 @@ class Client:
         remote_path = self._resolve_path(remote_path)
         data = {'file': remote_path}
         data = {'options': json.dumps(data, default=encode_pure_posix_path)}
-        logger.info(f"get_file {remote_path=}    {local_path=}")
         debug_start_time = time.perf_counter()
-        r = requests.post(urljoin(self._uit_url, 'getfile'), headers=self.headers, data=data, verify=self.ca_file,
-                          stream=True)
+        logger.info(f"get_file {remote_path=}    {local_path=}   {debug_start_time=}")
+        try:
+            r = requests.post(urljoin(self._uit_url, 'getfile'), headers=self.headers, data=data, verify=self.ca_file,
+                              stream=True, timeout=timeout)
+        except requests.Timeout as e:
+            raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
+
         if r.status_code != 200:
             raise RuntimeError("UIT returned a non-success status code ({}). The file '{}' may not exist, or you may "
                                "not have permission to access it.".format(r.status_code, remote_path))
@@ -522,11 +541,14 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def list_dir(self, path=None, parse=True, as_df=False):
+    def list_dir(self, path=None, parse=True, as_df=False, timeout=30):
         """Get a detailed directory listing from the HPC via the listdirectory endpoint.
 
         Args:
-            path (str): Directory to list
+            path (str): Directory to list.
+            parse (bool): False returns the output of 'ls -la', and True parses that into a JSON dictionary.
+            as_df (bool): Return a pandas DataFrame.
+            timeout(int): Number of seconds to limit the duration of the requests.post() call.
 
         Returns:
             str: The API response as JSON
@@ -540,9 +562,13 @@ class Client:
         data = {'options': json.dumps(data, default=encode_pure_posix_path)}
         logger.info(f"list_dir {path=}")
         debug_start_time = time.perf_counter()
-        r = requests.post(urljoin(self._uit_url, 'listdirectory'), headers=self.headers, data=data,
-                          verify=self.ca_file)
+        try:
+            r = requests.post(urljoin(self._uit_url, 'listdirectory'), headers=self.headers, data=data,
+                              verify=self.ca_file, timeout=timeout)
+        except requests.Timeout as e:
+            raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
+
         result = r.json()
 
         if as_df and 'path' in result:
@@ -787,15 +813,14 @@ class Client:
         if not logger.isEnabledFor(logging.DEBUG):
             return
 
-        debug_end_time = time.perf_counter()
-        time_text = f"{debug_end_time - local_vars['debug_start_time']:.2f}s"
-
-        debug_header = f" {FG_RED}time={time_text}{ALL_OFF}    node={self.login_node}"
-
         try:
             resp = local_vars['r'].json()
         except requests.exceptions.JSONDecodeError:
             resp = {}
+
+        debug_end_time = time.perf_counter()
+        time_text = f"{debug_end_time - local_vars['debug_start_time']:.2f}s"
+        debug_header = f" {FG_RED}time={time_text}{ALL_OFF}    node={self.login_node}"
 
         if resp.get('exitcode') is not None:
             debug_header += f"    rc={resp.get('exitcode')}"

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -251,6 +251,8 @@ class Client:
             login_node (str): Specific node name to connect to. Cannot be used with system arg.
             exclude_login_nodes (list): Nodes to exclude when selecting a login node. Ignored if login_node is
                 specified.
+            retry_on_failure (bool): True will attempt to connect to different login nodes.
+            num_retries (int): Number of connection attempts. Requires retry_on_failure=True
         """
         # get access token from file
         # populate userinfo and header info
@@ -276,7 +278,7 @@ class Client:
         self.connected = True
 
         try:
-            self.call(':')
+            self.call(':', working_dir='.', robust_retry=False)
         except UITError as e:
             self.connected = False
             msg = f'Error while connecting to node {login_node}: {e}'
@@ -398,17 +400,19 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def call(self, command, working_dir=None, full_response=False, raise_on_error=True):
+    def call(self, command, working_dir=None, full_response=False, raise_on_error=True, robust_retry=True):
         """Execute commands on the HPC via the exec endpoint.
 
         Args:
             command (str): The command to run.
             working_dir (str, optional, default=None): Working directory from which to run the command.
-                If None the the users $HOME directory will be used
+                If None the users $HOME directory will be used
             full_response(bool, default=False):
                 If True return the full JSON response from the UIT+ server.
             raise_on_error(bool, default=True):
                 If True then an error is raised if the call is not successful.
+            robust_retry(bool, default=True):
+                If False then skip the @robust decorator and its 3 connection attempts.
 
         Returns:
             str: stdout from the command.

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -243,7 +243,7 @@ class Client:
         import webbrowser
         webbrowser.open(auth_url)
 
-    def connect(self, system=None, login_node=None, exclude_login_nodes=(), retry_on_failure=False, num_retries=3):
+    def connect(self, system=None, login_node=None, exclude_login_nodes=(), retry_on_failure=None, num_retries=3):
         """Connect this client to the UIT servers.
 
         Args:
@@ -251,7 +251,10 @@ class Client:
             login_node (str): Specific node name to connect to. Cannot be used with system arg.
             exclude_login_nodes (list): Nodes to exclude when selecting a login node. Ignored if login_node is
                 specified.
-            retry_on_failure (bool): True will attempt to connect to different login nodes.
+            retry_on_failure (bool):
+                True will attempt to connect to different login nodes.
+                False will only attempt one connection.
+                Default of None will automatically pick False if login_node is set, otherwise it will pick True.
             num_retries (int): Number of connection attempts. Requires retry_on_failure=True
         """
         # get access token from file
@@ -261,6 +264,9 @@ class Client:
 
         if all([system, login_node]) or not any([system, login_node]):
             raise ValueError('Please specify at least one of system or login_node and not both')
+
+        if retry_on_failure is None:
+            retry_on_failure = login_node is None  # Default to no retry when only one login node is specified
 
         if login_node is None:
             # pick random login node for system

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -278,7 +278,8 @@ class Client:
         self.connected = True
 
         try:
-            self.call(':', working_dir='.', robust_retry=False)
+            # working_dir='.' ends up being the location for UIT+ scripts, not the user's home directory
+            self._call(':', working_dir='.')
         except UITError as e:
             self.connected = False
             msg = f'Error while connecting to node {login_node}: {e}'
@@ -400,7 +401,7 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def call(self, command, working_dir=None, full_response=False, raise_on_error=True, robust_retry=True):
+    def call(self, command, working_dir=None, full_response=False, raise_on_error=True):
         """Execute commands on the HPC via the exec endpoint.
 
         Args:
@@ -411,12 +412,14 @@ class Client:
                 If True return the full JSON response from the UIT+ server.
             raise_on_error(bool, default=True):
                 If True then an error is raised if the call is not successful.
-            robust_retry(bool, default=True):
-                If False then skip the @robust decorator and its 3 connection attempts.
 
         Returns:
             str: stdout from the command.
         """
+        return self._call(command, working_dir=working_dir, full_response=full_response, raise_on_error=raise_on_error)
+
+    def _call(self, command, working_dir=None, full_response=False, raise_on_error=True):
+        """Internal call function to avoid the 3 retries from @robust()"""
         # Need to do this manually to prevent recursive loop when resolving self.home
         working_dir = working_dir or self.HOME
 

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -268,60 +268,50 @@ class Client:
         if retry_on_failure is None:
             retry_on_failure = login_node is None  # Default to no retry when only one login node is specified
 
-        retry_on_dp_route_error = True
-        while num_retries >= 0:
-            if login_node is None:
-                # pick random login node for system
-                try:
-                    login_node = random.choice(list(set(self._login_nodes[system]) - set(exclude_login_nodes)))
-                except IndexError:
-                    msg = f'Error while connecting to {system}. No more login nodes to try.'
-                    logger.info(msg)
-                    raise MaxRetriesError(msg)
-
+        if login_node is None:
+            # pick random login node for system
             try:
-                system = [sys for sys, nodes in self._login_nodes.items() if login_node in nodes][0]
-            except Exception:
-                raise ValueError('{} login node not found in available nodes'.format(login_node))
-
-            self._login_node = login_node
-            self._system = system
-            self._username = self._userinfo['SYSTEMS'][self._system.upper()]['USERNAME']
-            self._uit_url = self._uit_urls[login_node]
-            self.connected = True
-
-            try:
-                # working_dir='.' ends up being the location for UIT+ scripts, not the user's home directory
-                self._call(':', working_dir='.', timeout=25)
-            except UITError as e:
-                if retry_on_dp_route_error is True \
-                        and str(e) == "DP Route error: Cannot read property 'LOCAL_IP' of undefined":
-                    # This is a very specific workaround. When UIT+ has to launch the user's RatchetHelper.jar, that one
-                    # command takes 10 seconds and fails, but another command to the same login node should work.
-                    logger.debug(f'Working around potential UIT+ RatchetHelper spawn issue. '
-                                 f'Trying {login_node} once more.')
-                    retry_on_dp_route_error = False
-                    continue
-
-                self.connected = False
-                msg = f'Error while connecting to node {login_node}: {e}'
+                login_node = random.choice(list(set(self._login_nodes[system]) - set(exclude_login_nodes)))
+            except IndexError:
+                msg = f'Error while connecting to {system}. No more login nodes to try.'
                 logger.info(msg)
-                if retry_on_failure is False:
-                    raise UITError(msg)
-                elif retry_on_failure is True and num_retries > 0:
-                    # Try a different login node
-                    logger.debug(f'Retrying connection {num_retries} more time(s) to this HPC {system}')
-                    num_retries -= 1
-                    exclude_login_nodes = list(exclude_login_nodes) + [login_node]
-                    login_node = None
-                    retry_on_dp_route_error = True
-                    continue
-                else:
-                    raise MaxRetriesError(msg)
+                raise MaxRetriesError(msg)
+
+        try:
+            system = [sys for sys, nodes in self._login_nodes.items() if login_node in nodes][0]
+        except Exception:
+            raise ValueError('{} login node not found in available nodes'.format(login_node))
+
+        self._login_node = login_node
+        self._system = system
+        self._username = self._userinfo['SYSTEMS'][self._system.upper()]['USERNAME']
+        self._uit_url = self._uit_urls[login_node]
+        self.connected = True
+
+        try:
+            # working_dir='.' ends up being the location for UIT+ scripts, not the user's home directory
+            self.call(':', working_dir='.', timeout=25)
+        except UITError as e:
+            self.connected = False
+            msg = f'Error while connecting to node {login_node}: {e}'
+            logger.info(msg)
+            if retry_on_failure is False:
+                raise UITError(msg)
+            elif retry_on_failure is True and num_retries > 0:
+                # Try a different login node
+                logger.debug(f'Retrying connection {num_retries} more time(s) to this HPC {system}')
+                num_retries -= 1
+                exclude_login_nodes = list(exclude_login_nodes) + [login_node]
+                return self.connect(
+                    system=system, exclude_login_nodes=exclude_login_nodes,
+                    retry_on_failure=retry_on_failure, num_retries=num_retries
+                )
             else:
-                msg = 'Connected successfully to {} on {}'.format(login_node, system)
-                logger.info(msg)
-                return msg
+                raise MaxRetriesError(msg)
+        else:
+            msg = 'Connected successfully to {} on {}'.format(login_node, system)
+            logger.info(msg)
+            return msg
 
     def get_auth_url(self):
         """Generate Authorization URL with UIT Server.
@@ -439,11 +429,6 @@ class Client:
         Returns:
             str: stdout from the command.
         """
-        return self._call(command, working_dir=working_dir, full_response=full_response,
-                          raise_on_error=raise_on_error, timeout=timeout)
-
-    def _call(self, command, working_dir=None, full_response=False, raise_on_error=True, timeout=120):
-        """Internal call function to avoid the 3 retries from @robust()"""
         # Need to do this manually to prevent recursive loop when resolving self.home
         working_dir = working_dir or self.HOME
 
@@ -483,7 +468,7 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def put_file(self, local_path, remote_path=None, timeout=20):
+    def put_file(self, local_path, remote_path=None, timeout=30):
         """Put files on the HPC via the putfile endpoint.
 
         Args:
@@ -515,7 +500,7 @@ class Client:
 
     @_ensure_connected
     @robust()
-    def get_file(self, remote_path, local_path=None, timeout=20):
+    def get_file(self, remote_path, local_path=None, timeout=30):
         """Get a file from the HPC via the getfile endpoint.
 
         Args:

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -270,7 +270,12 @@ class Client:
 
         if login_node is None:
             # pick random login node for system
-            login_node = random.choice(list(set(self._login_nodes[system]) - set(exclude_login_nodes)))
+            try:
+                login_node = random.choice(list(set(self._login_nodes[system]) - set(exclude_login_nodes)))
+            except IndexError:
+                msg = f'Error while connecting to {system}. No more login nodes to try.'
+                logger.info(msg)
+                raise MaxRetriesError(msg)
 
         try:
             system = [sys for sys, nodes in self._login_nodes.items() if login_node in nodes][0]

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -800,11 +800,11 @@ class Client:
             if not isinstance(debug_stacktrace_allowlist, list):
                 debug_stacktrace_allowlist = []
         else:
-            debug_stacktrace_allowlist = ['pyuit']
-        # This only shows the 'pyuit' directory by default. To change which directories are shown in the stacktrace,
+            debug_stacktrace_allowlist = ['uit']
+        # This only shows the 'uit' directory by default. To change which directories are shown in the stacktrace,
         # modify the PyUIT yaml config file (default location is ~/.uit) with a list like this:
         # debug_stacktrace_allowlist:
-        #   - pyuit
+        #   - uit
         #   - your_codebase_dir
 
         # To disable the stacktrace, put "debug_stacktrace_allowlist:" in the config file with no list below it

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -442,7 +442,7 @@ class Client:
         try:
             r = requests.post(urljoin(self._uit_url, 'exec'), headers=self.headers, data=data, verify=self.ca_file,
                               timeout=timeout)
-        except requests.Timeout as e:
+        except requests.Timeout:
             if raise_on_error:
                 raise UITError('Request Timeout')
             else:
@@ -492,7 +492,7 @@ class Client:
         try:
             r = requests.post(urljoin(self._uit_url, 'putfile'), headers=self.headers, data=data, files=files,
                               verify=self.ca_file, timeout=timeout)
-        except requests.Timeout as e:
+        except requests.Timeout:
             raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
 
@@ -522,7 +522,7 @@ class Client:
         try:
             r = requests.post(urljoin(self._uit_url, 'getfile'), headers=self.headers, data=data, verify=self.ca_file,
                               stream=True, timeout=timeout)
-        except requests.Timeout as e:
+        except requests.Timeout:
             raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
 
@@ -561,7 +561,7 @@ class Client:
         try:
             r = requests.post(urljoin(self._uit_url, 'listdirectory'), headers=self.headers, data=data,
                               verify=self.ca_file, timeout=timeout)
-        except requests.Timeout as e:
+        except requests.Timeout:
             raise UITError('Request Timeout')
         logger.debug(self._debug_uit(locals()))
 

--- a/uit/util.py
+++ b/uit/util.py
@@ -10,15 +10,18 @@ from functools import wraps
 from time import sleep
 from .exceptions import MaxRetriesError
 
+import logging
+logger = logging.getLogger(__name__)
 
-def robust(retries=3):
-    """
-    Robust wrapper for client methods. Will retry, reties times if failed due to DP routing error.
-    """  # noqa: E501
+
+def robust(retries=1):
+    """Robust wrapper for client methods. Will retry, reties times if failed due to DP routing error.
+
+    This is set to 1 retry because UIT+ should repair the SSH Tunnel immediately."""
     def wrap(func):
         @wraps(func)
         def wrap_f(*args, **kwargs):
-            attempts = 1
+            attempts = 0
 
             last_exception = None
 
@@ -29,14 +32,17 @@ def robust(retries=3):
                     # "DP Route error" indicates failure of SSH Tunnel client on UIT Plus server.
                     # Successive calls should work.
                     if 'DP Route error' in str(e):
+                        if attempts < retries:
+                            logger.info(
+                                f"DP Route error detected, @robust() is retrying {retries - attempts} more time(s).")
                         attempts += 1
                         last_exception = e
                         sleep(1)
                     else:
                         # Raise other Runtime Errors
                         raise
-            kwarg_str = ', '.join(['{}="{}"'.format(k, v) for k, v in kwargs.items()])
 
+            kwarg_str = ', '.join(['{}="{}"'.format(k, v) for k, v in kwargs.items()])
             raise MaxRetriesError(
                 f'Max number of retries reached without success for method: {func.__name__}({kwarg_str}). '
                 f'Last exception encountered: {last_exception}'

--- a/uit/util.py
+++ b/uit/util.py
@@ -18,9 +18,6 @@ def robust(retries=3):
     def wrap(func):
         @wraps(func)
         def wrap_f(*args, **kwargs):
-            if kwargs.get("robust_retry") is False:
-                return func(*args, **kwargs)
-
             attempts = 1
 
             last_exception = None

--- a/uit/util.py
+++ b/uit/util.py
@@ -11,13 +11,16 @@ from time import sleep
 from .exceptions import MaxRetriesError
 
 
-def robust(retries=5):
+def robust(retries=3):
     """
     Robust wrapper for client methods. Will retry, reties times if failed due to DP routing error.
     """  # noqa: E501
     def wrap(func):
         @wraps(func)
         def wrap_f(*args, **kwargs):
+            if kwargs.get("robust_retry") is False:
+                return func(*args, **kwargs)
+
             attempts = 1
 
             last_exception = None
@@ -31,11 +34,10 @@ def robust(retries=5):
                     if 'DP Route error' in str(e):
                         attempts += 1
                         last_exception = e
-                        continue
+                        sleep(1)
                     else:
                         # Raise other Runtime Errors
                         raise
-                sleep(1)
             kwarg_str = ', '.join(['{}="{}"'.format(k, v) for k, v in kwargs.items()])
 
             raise MaxRetriesError(


### PR DESCRIPTION
CHW-429 Broken login node causes 25 retries
This task started when one login node went down, and PyUIT tried to connect to it 25 times and never tried another login node. This PR will:

- Change @robust() from 5 retries to 1 retry. It only retried for one specific error which UIT+ should fix within one attempt, or else UIT+ is very broken.
- Attempt to connect to other login nodes if it is not given a specific login node to connect to.
- Avoid an exception if it wants to retry but has no more login nodes to try.
- Add reasonable timeouts to calls to requests.post(), and added a keyword argument to the main functions.
- Side fix: removed an unnecessary HPC call in File Browser.
- Side fix: changed debug stacktrace default to 'uit' to correctly match the deployed package name.

Connecting to an HPC will normally try 4 login nodes with one attempt each, unless it sees a DP Route Error which will give one more attempt to that login node.