### PR TITLE
Add optional debug logging steps to Jupyter Notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 
 # ViM Files
 *.swp
+
+# Jupyter Notebook Checkpoints
+.ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ target/
 # ViM Files
 *.swp
 
-# Jupyter Notebook Checkpoints
+# Jupyter Notebook checkpoints
 .ipynb_checkpoints

--- a/examples/auth_popup.ipynb
+++ b/examples/auth_popup.ipynb
@@ -44,6 +44,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## (Optional) Enable Debug Logging\n",
+    "\n",
+    "This will display every command sent to the HPC through UIT+, which login node was used, how long each command took, and a very brief stacktrace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "handler = logging.StreamHandler()\n",
+    "formatter = logging.Formatter('%(asctime)s %(levelname)s:%(name)s:%(message)s')\n",
+    "handler.setFormatter(formatter)\n",
+    "logger = logging.getLogger('uit')\n",
+    "logger.handlers.clear()\n",
+    "logger.addHandler(handler)\n",
+    "logger.setLevel('DEBUG')\n",
+    "logger.debug('Test pyuit debug logging')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### This will popup a new browser window/tab for the Authentication"
    ]
   },
@@ -121,7 +147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/examples/pyUIT Demo.ipynb
+++ b/examples/pyUIT Demo.ipynb
@@ -38,6 +38,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## (Optional) Enable Debug Logging\n",
+    "\n",
+    "This will display every command sent to the HPC through UIT+, which login node was used, how long each command took, and a very brief stacktrace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "handler = logging.StreamHandler()\n",
+    "formatter = logging.Formatter('%(asctime)s %(levelname)s:%(name)s:%(message)s')\n",
+    "handler.setFormatter(formatter)\n",
+    "logger = logging.getLogger('uit')\n",
+    "logger.handlers.clear()\n",
+    "logger.addHandler(handler)\n",
+    "logger.setLevel('DEBUG')\n",
+    "logger.debug('Test pyuit debug logging')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Authenticating and Connecting\n",
     "\n",
     "The first step in using pyUIT is to create a `uit.Client` and authenticate a user to the UIT+ server. Users must have a pIE account to access the HPC. If your pIE account was created recently (after 2018ish) then you must request that your account be synced to the UIT+ server. \n",
@@ -61,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we need to connect to a specific HPC system. Currently `onyx` is the only available system. Soon `jim` will be added, and other DSRC systems can be added in the future. "
+    "Next, we need to connect to a specific HPC system. Currently `onyx`, `narwhal`, and `mustang` are the available systems. Other DSRC systems can be added in the future. "
    ]
   },
   {
@@ -86,7 +112,7 @@
    "source": [
     "## Basic Usage\n",
     "\n",
-    "By default, the `call` method will execute the command in the users $HOME directory. You can optionally pass in a `work_dir` argument to specify a different directory."
+    "By default, the `call` method will execute the command in the users $HOME directory. You can optionally pass in a `working_dir` argument to specify a different directory."
    ]
   },
   {
@@ -102,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we passed in `c.WORKDIR` as the value for the `working_dir` argument. The `uit.Client` object has a few properties for common environment variables that are returned as `PosixPath` objects. Other environment variables that can be accesed as properties include:"
+    "Note that we passed in `c.WORKDIR` as the value for the `working_dir` argument. The `uit.Client` object has a few properties for common environment variables that are returned as `PosixPath` objects. Other environment variables that can be accessed as properties include:"
    ]
   },
   {
@@ -383,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This adds debug logging steps to 2 of the 5 Jupyter Notebook examples: pyUIT Demo and auth_popup. It also updates and fixes a couple lines in pyUIT Demo.

And it hides checkpoint files from git.