### PR TITLE
Fix PBS parsing bug

### DIFF
--- a/uit/job.py
+++ b/uit/job.py
@@ -455,14 +455,13 @@ def get_job_from_id(job_id, uit_client, with_historic=True):
 
 
 def _process_l_directives(pbs_script):
-    matches = re.findall('#PBS -l (.*)', pbs_script)
+    matches = re.findall(r'^#PBS -l (.*)', pbs_script, flags=re.MULTILINE)
     d = dict()
     for match in matches:
         if 'walltime' in match:
             d['walltime'] = match.split('=')[1]
         else:
-            d.update({k: v for k, v in [i.split('=') for i in matches[0].split(':')]})
-
+            d.update({k: v for k, v in [i.split('=') for i in match.split(':')]})
     return d
 
 
@@ -471,7 +470,7 @@ def get_job_from_pbs_script(job_id, pbs_script, uit_client):
     working_dir = script.parent
     logger.debug(f'PBS script parent: {working_dir}')
     pbs_script = uit_client.call(f'cat {pbs_script}')
-    matches = re.findall('#PBS -(.*)', pbs_script)
+    matches = re.findall(r'^#PBS -(.*)', pbs_script, flags=re.MULTILINE)
     directives = {k: v for k, v in [(i.split() + [''])[:2] for i in matches]}
     directives['l'] = _process_l_directives(pbs_script)
 

--- a/uit/pbs_script.py
+++ b/uit/pbs_script.py
@@ -190,7 +190,7 @@ class PbsScript(object):
 
     @property
     def job_array_directives(self):
-        if self._array_indices is not None:
+        if self._array_indices:
             options = f'{self._array_indices[0]}-{self._array_indices[1]}'
             try:
                 options += f':{self._array_indices[2]}'
@@ -205,9 +205,9 @@ class PbsScript(object):
 
     @property
     def job_array_indices(self):
-        if self._array_indices is not None:
+        if self._array_indices:
             indices = list(self._array_indices)
-            indices[1] += 1  # unlike Python PBS is inclusive of the last index
+            indices[1] += 1  # unlike Python, PBS is inclusive of the last index
             return list(range(*indices))
 
     def set_directive(self, directive, value):

--- a/uit/testing_utils.py
+++ b/uit/testing_utils.py
@@ -92,9 +92,12 @@ class MockClient(Client):
 
     def list_dir(self, path=None, parse=True, as_df=False):
         p = Path(path)
-        dirs = [{'name': x.name, 'path': str(x)} for x in p.iterdir() if x.is_dir()]
-        files = [{'name': x.name, 'path': str(x)} for x in p.iterdir() if x.is_file()]
-        return {'dirs': dirs, 'files': files}
+        try:
+            dirs = [{'name': x.name, 'path': str(x)} for x in p.iterdir() if x.is_dir()]
+            files = [{'name': x.name, 'path': str(x)} for x in p.iterdir() if x.is_file()]
+            return {'dirs': dirs, 'files': files}
+        except NotADirectoryError:
+            return {'success': 'false', 'error': 'File supplied is not a directory.'}
 
 
 mock_client = MockClient()

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -822,14 +822,16 @@ class Client:
         time_text = f"{debug_end_time - local_vars['debug_start_time']:.2f}s"
         debug_header = f" {FG_RED}time={time_text}{ALL_OFF}    node={self.login_node}"
 
+        local_file_size = None
         if local_vars.get('local_file_size'):
-            debug_header += f"    filesize={local_vars['local_file_size']}"
+            local_file_size = int(local_vars['local_file_size'])
         elif local_vars.get('local_path'):
             try:
                 local_file_size = local_vars['local_path'].stat().st_size
-                debug_header += f"    filesize={local_file_size}"
             except OSError:
                 pass
+        if local_file_size is not None:
+            debug_header += f"    filesize={local_file_size:,}"
 
         if resp.get('exitcode') is not None:
             debug_header += f"    rc={resp.get('exitcode')}"


### PR DESCRIPTION
This code had a bug where it would string split on colons only on the first "#PBS -l" line, not every "#PBS -l" line. I never noticed it because the first "-l" line is almost always "select=#:ncpus=#:mpiprocs=#".

It now ignores "commented" lines like "##PBS -l".

I also threw in some minor tweaks that I have been testing for a while. pbs_script.py has a couple more resilience changes for data migrations, just like https://github.com/erdc/pyuit/pull/42/commits/50f4ddb7c9a826ed0ec2c56d670ac6330d3fdc40. Debug file sizes now have commas.

CHW-479
