### PR TITLE
Refactor logs and update_status

### DIFF
--- a/uit/gui_tools/connect.py
+++ b/uit/gui_tools/connect.py
@@ -140,7 +140,7 @@ class HpcConnect(param.Parameterized):
         connect_btn = pn.widgets.Button.from_param(self.param.connect_btn, button_type='success', width=100)
         connect_btn.js_on_click(
             args={'btn': connect_btn, },
-            code='btn.css_classes.push("pn-loading", "arcs"); btn.properties.css_classes.change.emit();'
+            code='btn.css_classes.push("pn-loading", "arc"); btn.properties.css_classes.change.emit();'
         )
 
         if self.connected is None:

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -344,7 +344,7 @@ class FileBrowser(param.Parameterized):
             self, parameters=self.controls + ['path_text'], widgets=self.control_styles, show_name=False,
         )[:]
         args = {'listing': self.file_listing_widget}
-        code = 'listing.css_classes.push("pn-loading", "arcs"); listing.properties.css_classes.change.emit();'
+        code = 'listing.css_classes.push("pn-loading", "arc"); listing.properties.css_classes.change.emit();'
         self.file_listing_widget.jscallback(args=args, value=code)
         for wg in widgets[:-1]:
             wg.js_on_click(args=args, code=code)
@@ -589,7 +589,7 @@ class FileSelector(param.Parameterized):
 
         browse_toggle.js_on_click(
             args={'btn': browse_toggle},
-            code='btn.css_classes.push("pn-loading", "arcs"); btn.properties.css_classes.change.emit();',
+            code='btn.css_classes.push("pn-loading", "arc"); btn.properties.css_classes.change.emit();',
         )
 
         return pn.Row(file_path, browse_toggle, width_policy='max', margin=0)
@@ -671,10 +671,14 @@ class FileViewer(param.Parameterized):
     @param.depends('update_btn')
     def view(self):
         file_path = self.file_select.file_path
+        viewer = pn.widgets.Ace(
+            value=self.file_contents, min_height=500, sizing_mode='stretch_both',
+            readonly=True, filename=file_path, theme='monokai',
+        )
         return pn.Column(
             pn.widgets.TextInput(value=file_path, disabled=True),
-            pn.widgets.Ace(value=self.file_contents, min_height=500, sizing_mode='stretch_both',
-                           readonly=True, filename=file_path),
+            viewer.param.theme,
+            viewer,
             sizing_mode='stretch_both',
         )
 

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -167,7 +167,7 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         btn.on_click(self.update_environ)
         btn.js_on_click(
             args={'btn': btn},
-            code='btn.css_classes.push("pn-loading", "arcs"); btn.properties.css_classes.change.emit();'
+            code='btn.css_classes.push("pn-loading", "arc"); btn.properties.css_classes.change.emit();'
         )
         return btn
 
@@ -206,7 +206,7 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         new_val_wg = self.env_var_widget(val=None, tag='env_val_-1', disabled=True)
         new_key_wg.jscallback(
             args={'val': new_val_wg},
-            value='val.css_classes.push("pn-loading", "arcs"); val.properties.css_classes.change.emit();'
+            value='val.css_classes.push("pn-loading", "arc"); val.properties.css_classes.change.emit();'
         )
         self.env_names.append(new_key_wg)
         self.env_values.append(new_val_wg)
@@ -380,7 +380,7 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
         action_btn = pn.widgets.Button.from_param(self.param[button], button_type=button_type, width=200)
         cancel_btn = pn.widgets.Button.from_param(self.param.cancel_btn, button_type='danger', width=200)
 
-        code = 'btn.css_classes.push("pn-loading", "arcs"); btn.properties.css_classes.change.emit(); ' \
+        code = 'btn.css_classes.push("pn-loading", "arc"); btn.properties.css_classes.change.emit(); ' \
                'other_btn.disabled=true;'
         action_btn.js_on_click(
             args={'btn': action_btn, 'other_btn': cancel_btn},

--- a/uit/job.py
+++ b/uit/job.py
@@ -485,7 +485,10 @@ class PbsArrayJob(PbsJob):
             """
             Resolves strings with variables relating to the job id.
             """
-            path = PurePosixPath(path).as_posix()
+            pppath = PurePosixPath(path)
+            path = pppath.as_posix()
+            if not pppath.is_absolute() and '$RUN_DIR' not in path:
+                path = f'$RUN_DIR/{path}'  # resolve relative to sub-job run directory
             path = path.replace('$JOB_INDEX', str(self.job_index))
             path = path.replace('$RUN_DIR', self.run_dir_name)
             return super().resolve_path(path)


### PR DESCRIPTION
Change css class in jscallbacks so spinner will appear
Add Ace widget to logs tab to format logs better
Add Ace theme to logs and file viewer
Add PbsJob's post processing job to delete and status commands Refactor logs to download and cache the log file
Add extra variables to ``resolve_path``
Logs tab now only returns the last 100_000 bytes of the file to prevent crashing the browser. Refactor Statuses tab to only load cached status on load.