### PR TITLE
Improve environment profiles

### DIFF
--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -184,9 +184,6 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         else:
             self.env_values[index].value = self.file_browser.value[0]
 
-    def get_versions(self, uit_client):
-        return []
-
     @param.depends('environment_variables')
     def environment_variables_view(self):
         self.environment_variables.pop('', None)  # Clear blank key if there is one
@@ -194,23 +191,12 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         self.env_values = list()
         self.env_browsers = list()
         self.env_delete_buttons = list()
-        alert_pane = pn.pane.Str('')
 
         for i, (k, v) in enumerate(self.environment_variables.items()):
-            if k == 'HELIOS_VERSION':
-                if v not in self.get_versions(self.uit_client):
-                    alert_pane = pn.pane.Alert(alert_type='warning', object=f'Environment profile Helios version {v} is not in the list of current Helios software. Resetting to {self.get_versions(self.uit_client)[0]}')
-                    v = self.get_versions(self.uit_client)[0]
-                name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}', disabled=True)
-                val_widget = pn.widgets.Select(value=v, options=self.param.version.objects, css_classes=[f'env_val_{i}'], tag=f'env_val_{i}')
-                val_widget.param.watch(self.update_environ, ['value'], onlychanged=True)
-                browser_widget = None
-                delete_btn = None
-            else:
-                name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}')
-                val_widget = self.env_var_widget(val=str(v), tag=f'env_val_{i}')
-                browser_widget = self.env_file_browser_widget(tag=f'env_browser_{i}')
-                delete_btn = self.env_delete_btn(tag=f'env_del_{i}')
+            name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}')
+            val_widget = self.env_var_widget(val=str(v), tag=f'env_val_{i}')
+            browser_widget = self.env_file_browser_widget(tag=f'env_browser_{i}')
+            delete_btn = self.env_delete_btn(tag=f'env_del_{i}')
             self.env_names.append(name_widget)
             self.env_values.append(val_widget)
             self.env_browsers.append(browser_widget)
@@ -229,7 +215,6 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         self.env_values[0].name = 'Value'
 
         return pn.Card(
-            *[pn.Row(alert_pane)],
             *[pn.Row(k, v, b, d, sizing_mode='stretch_width') for k, v, b, d in
               zip_longest(self.env_names, self.env_values, self.env_browsers, self.env_delete_buttons)],
             self.file_browser_col,

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -184,6 +184,9 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         else:
             self.env_values[index].value = self.file_browser.value[0]
 
+    def get_versions(self, uit_client):
+        return []
+
     @param.depends('environment_variables')
     def environment_variables_view(self):
         self.environment_variables.pop('', None)  # Clear blank key if there is one
@@ -191,12 +194,23 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         self.env_values = list()
         self.env_browsers = list()
         self.env_delete_buttons = list()
+        alert_pane = pn.pane.Str('')
 
         for i, (k, v) in enumerate(self.environment_variables.items()):
-            name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}')
-            val_widget = self.env_var_widget(val=str(v), tag=f'env_val_{i}')
-            browser_widget = self.env_file_browser_widget(tag=f'env_browser_{i}')
-            delete_btn = self.env_delete_btn(tag=f'env_del_{i}')
+            if k == 'HELIOS_VERSION':
+                if v not in self.get_versions(self.uit_client):
+                    alert_pane = pn.pane.Alert(alert_type='warning', object=f'Environment profile Helios version {v} is not in the list of current Helios software. Resetting to {self.get_versions(self.uit_client)[0]}')
+                    v = self.get_versions(self.uit_client)[0]
+                name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}', disabled=True)
+                val_widget = pn.widgets.Select(value=v, options=self.param.version.objects, css_classes=[f'env_val_{i}'], tag=f'env_val_{i}')
+                val_widget.param.watch(self.update_environ, ['value'], onlychanged=True)
+                browser_widget = None
+                delete_btn = None
+            else:
+                name_widget = self.env_var_widget(val=k, tag=f'env_key_{i}')
+                val_widget = self.env_var_widget(val=str(v), tag=f'env_val_{i}')
+                browser_widget = self.env_file_browser_widget(tag=f'env_browser_{i}')
+                delete_btn = self.env_delete_btn(tag=f'env_del_{i}')
             self.env_names.append(name_widget)
             self.env_values.append(val_widget)
             self.env_browsers.append(browser_widget)
@@ -215,6 +229,7 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
         self.env_values[0].name = 'Value'
 
         return pn.Card(
+            *[pn.Row(alert_pane)],
             *[pn.Row(k, v, b, d, sizing_mode='stretch_width') for k, v, b, d in
               zip_longest(self.env_names, self.env_values, self.env_browsers, self.env_delete_buttons)],
             self.file_browser_col,

--- a/uit/gui_tools/utils.py
+++ b/uit/gui_tools/utils.py
@@ -27,11 +27,11 @@ class HpcConfigurable(param.Parameterized):
     modules_to_unload = param.ListSelector(default=[])
 
     @param.depends('uit_client', watch=True)
-    def update_configurable_hpc_parameters(self):
+    def update_configurable_hpc_parameters(self, reset=False):
         if not (self.uit_client and self.uit_client.connected):
             return
 
-        self.load_config_file()
+        self.load_config_file(reset = reset)
         self.param.modules_to_unload.objects = sorted(self.uit_client.get_loaded_modules())
         self.param.modules_to_load.objects = self._get_modules_available_to_load()
         self.modules_to_load = self._validate_modules(self.param.modules_to_load.objects, self.modules_to_load)
@@ -62,7 +62,7 @@ class HpcConfigurable(param.Parameterized):
                 logger.info(f'Module "{m}" is  invalid.')
         return sorted(modules)
 
-    def load_config_file(self):
+    def load_config_file(self, reset=False):
         config_file = Path(self.configuration_file)
         if config_file.is_file():
             with config_file.open() as f:
@@ -71,6 +71,9 @@ class HpcConfigurable(param.Parameterized):
             if modules:
                 self.modules_to_load = self.modules_to_load or modules.get('load')
                 self.modules_to_unload = self.modules_to_unload or modules.get('unload')
+            if reset:
+                self.environment_variables = OrderedDict(config.get('environment_variables'))
+            else:
             self.environment_variables = self.environment_variables or OrderedDict(config.get('environment_variables'))
 
 

--- a/uit/gui_tools/utils.py
+++ b/uit/gui_tools/utils.py
@@ -74,7 +74,7 @@ class HpcConfigurable(param.Parameterized):
             if reset:
                 self.environment_variables = OrderedDict(config.get('environment_variables'))
             else:
-            self.environment_variables = self.environment_variables or OrderedDict(config.get('environment_variables'))
+                self.environment_variables = self.environment_variables or OrderedDict(config.get('environment_variables'))
 
 
 class HpcWorkspaces(HpcConfigurable):

--- a/uit/gui_tools/utils.py
+++ b/uit/gui_tools/utils.py
@@ -31,7 +31,7 @@ class HpcConfigurable(param.Parameterized):
         if not (self.uit_client and self.uit_client.connected):
             return
 
-        self.load_config_file(reset = reset)
+        self.load_config_file(reset=reset)
         self.param.modules_to_unload.objects = sorted(self.uit_client.get_loaded_modules())
         self.param.modules_to_load.objects = self._get_modules_available_to_load()
         self.modules_to_load = self._validate_modules(self.param.modules_to_load.objects, self.modules_to_load)


### PR DESCRIPTION
PR for improving environment profile capabilities. Fixed a bug when switching from loaded profile to creating a new one from template. Made the HELIOS_VERSION variable required and provided the user a drop down selection of valid choices from the host. Added a check to ensure that the loaded profile is current, and resets the selected version to one that the HPC supports, if it is not.