### PR TITLE
Added 'environment_variables' to @param.depends() in is_submitable()

### DIFF
--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -354,7 +354,7 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
     def execution_block(self):
         return ''
 
-    @param.depends('job_name', watch=True)
+    @param.depends('job_name', 'environment_variables', watch=True)
     def is_submitable(self):
         self.error_messages[:] = []
         if not self.job_name:


### PR DESCRIPTION
Allows for the override function in helios-workflows > submit_stage.py to work properly when updating error messages for Helios Versions