### PR TITLE
Fix show usage with csh

### DIFF
--- a/uit/uit.py
+++ b/uit/uit.py
@@ -282,7 +282,7 @@ class Client:
 
         try:
             # working_dir='.' ends up being the location for UIT+ scripts, not the user's home directory
-            self.call(':', working_dir='.', timeout=25)
+            self.call(':', working_dir='.', timeout=35)
         except UITError as e:
             self.connected = False
             msg = f'Error while connecting to node {login_node}: {e}'

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -579,7 +579,9 @@ class Client:
         Returns:
             str: The API response
         """
-        result = self.call('show_usage')
+        # 'module reload' is a workaround for users with a default shell of /bin/csh on Warhawk.
+        # UIT+ runs commands in a bash script, and that combination drops part of the PATH for show_usage.
+        result = self.call('module reload >/dev/null 2>&1; show_usage')
         if not parse:
             return result
 


### PR DESCRIPTION
When the user's default shell is /bin/csh, pyuit fails to run "show_usage" on Warhawk with the error "show_usage: command not found". UIT+ runs every command in a bash script, and there is something on there that prevents the PATH from transferring from csh to bash. It says it keeps all 19 modules loaded when switching shells, but the one for show_usage doesn't append to the PATH again. Warhawk uses a much newer version of Modulefiles compared to the other systems.

Running "module reload" before show_usage gets around the problem, but it takes a 3-5 seconds to run this new command compared to 0.5-0.9 seconds for only show_usage.

This also increases the connect timeout from 25 to 35 seconds because UIT+ tends to take 28-32 seconds to build a connection to Warhawk.

CHW 579