### PR TITLE
Avoid changing to sub_job directory for certain log files

### DIFF
--- a/uit/job.py
+++ b/uit/job.py
@@ -498,8 +498,6 @@ class PbsArrayJob(PbsJob):
             """
             pppath = PurePosixPath(path)
             path = pppath.as_posix()
-            if not pppath.is_absolute() and '$RUN_DIR' not in path:
-                path = f'$RUN_DIR/{path}'  # resolve relative to sub-job run directory
             path = path.replace('$JOB_INDEX', str(self.job_index))
             path = path.replace('$RUN_DIR', self.run_dir_name)
             return super().resolve_path(path)

--- a/uit/job.py
+++ b/uit/job.py
@@ -434,7 +434,8 @@ class PbsJob:
                     and status['status'] not in ('Q', 'H', 'B')
                     and not isinstance(job, PbsArrayJob)
             ):
-                if job._qstat['elapsed_time'][-1] != '*': job._qstat['elapsed_time'] += '*'
+                if job._qstat['elapsed_time'][-1] != '*':
+                    job._qstat['elapsed_time'] += '*'
                 job._qstat['status'] = status['status']
             else:
                 job._qstat = status


### PR DESCRIPTION
This was causing any log file with $JOB_INDEX to look in the sub_job's $RUN_DIR when the log file actually lived in the parent directory. This prevented access to PBS stdout and stderr logs. If something needs to download log files from a sub_job, it can still reference $RUN_DIR for it.

CHW 600