### PR TITLE
Avoid 'module: command not found' error

### DIFF
--- a/uit/pbs_script.py
+++ b/uit/pbs_script.py
@@ -332,7 +332,9 @@ class PbsScript(object):
         Returns:
             str: All module calls.
         """
-        opt_list = [self._create_block_header_string('Modules')]
+        opt_list = [self._create_block_header_string('Modules'),
+                    "# Avoid 'module: command not found' error when default shell is /bin/csh",
+                    "source ${MODULESHOME}/init/bash"]
         for path in self._module_use:
             opt_list.append(f'module use --append {path}')
         for key, value in self._modules.items():


### PR DESCRIPTION
This error only happens when the user's default shell is /bin/csh on one HPC. Before, the PBS script would fail to load every module and then fail to run any related commands.

I have not tested this change with a default shell of /bin/bash. Edit: I tested bash, and it works well.

This is one way to fix the problem. The other method involves adding a "#PBS -S /bin/bash" line to the PBS script, but that added a couple of csh syntax errors to the logs on a different HPC.

CHW-578