### PR TITLE
Handle json error responses

### DIFF
--- a/uit/uit.py
+++ b/uit/uit.py
@@ -364,6 +364,7 @@ class Client:
         self.token = token.json()['access_token']
         self._do_callback(True)
 
+    @robust()
     def get_userinfo(self):
         """Get User Info from the UIT server."""
         # request user info from UIT site


### PR DESCRIPTION
This handles responses back from UIT+ that could contain errors which are not in JSON format. It sends the entire error text to the log file which can help with troubleshooting.

This also adds a retry to get_userinfo() in case it gets an immediate Connection Aborted.

CHW-471