### PR TITLE
Subproject table overlaps card border

### DIFF
--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -3,6 +3,7 @@ import logging
 from functools import partial
 from itertools import zip_longest
 
+from bokeh.models import NumberFormatter
 import param
 import panel as pn
 
@@ -143,6 +144,12 @@ class PbsScriptInputs(param.Parameterized):
                         width=self.SHOW_USAGE_TABLE_MAX_WIDTH,
                         show_index=False,
                         disabled=True,
+                        formatters={
+                            'hours_allocated': NumberFormatter(format='0,0'),
+                            'hours_used': NumberFormatter(format='0,0'),
+                            'hours_remaining': NumberFormatter(format='0,0'),
+                            'background_hours_used': NumberFormatter(format='0,0'),
+                        },
                     ),
                     title='Subproject Usage Summary',
                     collapsed=True,

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -138,11 +138,14 @@ class PbsScriptInputs(param.Parameterized):
         return pn.Column(
             pn.Column(
                 pn.Card(
-                    pn.widgets.Tabulator.from_param(self.param.subproject_usage, width=self.SHOW_USAGE_TABLE_MAX_WIDTH),
+                    pn.widgets.Tabulator.from_param(
+                        self.param.subproject_usage,
+                        width=self.SHOW_USAGE_TABLE_MAX_WIDTH,
+                    ),
                     title='Subproject Usage Summary',
-                    sizing_mode='stretch_width',
                     collapsed=True,
                     margin=(10, 0),
+                    width=self.SHOW_USAGE_TABLE_MAX_WIDTH + 20,
                 )
             ),
             pn.Column(

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -33,7 +33,7 @@ class PbsScriptInputs(param.Parameterized):
     notify_start = param.Boolean(default=True, label='when job begins', precedence=9.1)
     notify_end = param.Boolean(default=True, label='when job ends', precedence=9.2)
 
-    SHOW_USAGE_TABLE_MAX_WIDTH = 1030
+    SHOW_USAGE_TABLE_MAX_WIDTH = 960
     DEFAULT_PROCESSES_PER_JOB = 500
     wall_time_maxes = None
     node_maxes = None
@@ -141,6 +141,8 @@ class PbsScriptInputs(param.Parameterized):
                     pn.widgets.Tabulator.from_param(
                         self.param.subproject_usage,
                         width=self.SHOW_USAGE_TABLE_MAX_WIDTH,
+                        show_index=False,
+                        disabled=True,
                     ),
                     title='Subproject Usage Summary',
                     collapsed=True,

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -50,7 +50,7 @@ class PbsScriptInputs(param.Parameterized):
         queues_stats = self.uit_client.get_raw_queue_stats()
 
         self.subproject_usage = self.uit_client.show_usage(as_df=True)
-        subprojects = self.subproject_usage.subproject.to_list()
+        subprojects = self.subproject_usage['Subproject'].to_list()
         self.param.hpc_subproject.objects = subprojects
         self.hpc_subproject = self.get_default(self.hpc_subproject, subprojects)
         self.workdir = self.uit_client.WORKDIR.as_posix()
@@ -145,10 +145,10 @@ class PbsScriptInputs(param.Parameterized):
                         show_index=False,
                         disabled=True,
                         formatters={
-                            'hours_allocated': NumberFormatter(format='0,0'),
-                            'hours_used': NumberFormatter(format='0,0'),
-                            'hours_remaining': NumberFormatter(format='0,0'),
-                            'background_hours_used': NumberFormatter(format='0,0'),
+                            'Hours Allocated': NumberFormatter(format='0,0'),
+                            'Hours Used': NumberFormatter(format='0,0'),
+                            'Hours Remaining': NumberFormatter(format='0,0'),
+                            'Background Hours Used': NumberFormatter(format='0,0'),
                         },
                     ),
                     title='Subproject Usage Summary',

--- a/uit/uit.py
+++ b/uit/uit.py
@@ -789,8 +789,8 @@ class Client:
                 if line:
                     name_part = line[col_start: col_end].strip()
                     if name_part:
-                        col_name.append(name_part.lower().replace(' ', '_'))
-            columns.append('_'.join(col_name))
+                        col_name.append(name_part)
+            columns.append(' '.join(col_name))
             col_start = col_end
         return columns
 


### PR DESCRIPTION
The "Subproject Usage Summary" table draws over the right edge of the Card. This PR fixes that by removing the 'stretch_width' and setting the Card's width to 20 more pixels to account for the margin.

It also changes the column headers from snake_case to Capital Words. I had to change one line that used the column headers to fetch data, and I hope that was all. Other changes include removing the index column, adding thousands separators, and disable table editing.

CHW-644 includes screenshots of before and after.