### PR TITLE
Add hover highlight to FileBrowser widget

### DIFF
--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -338,7 +338,9 @@ class FileBrowser(param.Parameterized):
     @param.depends('_disabled')
     def panel(self):
         self.file_listing_widget = pn.widgets.MultiSelect.from_param(
-            self.param.file_listing, height=200, width_policy='max'
+            self.param.file_listing, height=200, width_policy='max',
+            stylesheets=[".bk-input option:hover { "
+                         "background-color: var(--design-surface-color, var(--primary-bg-subtle)); }"],
         )
         widgets = pn.Param(
             self, parameters=self.controls + ['path_text'], widgets=self.control_styles, show_name=False,


### PR DESCRIPTION
This adds a light background color change when the mouse is hovering over a file in FileBrowser. This might help me avoid clicking the wrong file occasionally. The color can be overridden by something like `pn.extension(global_css=[':root { --design-surface-color: #dcf0fd; }'])` as described in https://panel.holoviz.org/how_to/styling/design_variables.html. If that is not defined, it will fall back to the `--primary-bg-subtle` variable defined in Panel's `themes/default.css`.
    
CHW-434