### PR TITLE
Fix ParamFutureWarning with ClassSelector

### DIFF
--- a/examples/pyUIT GUI Tools Demo.ipynb
+++ b/examples/pyUIT GUI Tools Demo.ipynb
@@ -145,7 +145,7 @@
     "        )\n",
     "    \n",
     "class HpcJobScriptEditor(param.Parameterized):\n",
-    "    uit_client = param.ClassSelector(Client)\n",
+    "    uit_client = param.ClassSelector(class_=Client)\n",
     "    file_type = param.ObjectSelector(default='sh', objects=['py', 'sh'])\n",
     "    file_contents = param.String(default='echo Hello World!')\n",
     "    ready = param.Boolean(default=False, precedence=-1)\n",

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -59,7 +59,7 @@ class FileManagerHPC(FileManager):
 
     """
 
-    uit_client = param.ClassSelector(Client, precedence=-1)
+    uit_client = param.ClassSelector(class_=Client, precedence=-1)
 
     @param.depends("uit_client", watch=True)
     def _initialize_directory(self):
@@ -97,7 +97,7 @@ class FileManagerHPC(FileManager):
 
 
 class FileTransfer(param.Parameterized):
-    uit_client = param.ClassSelector(Client, precedence=-1)
+    uit_client = param.ClassSelector(class_=Client, precedence=-1)
 
     from_location = param.Selector(default="local", objects=["local"], precedence=0.21)
     from_directory = param.String(precedence=0.22)
@@ -193,7 +193,7 @@ class FileTransfer(param.Parameterized):
 class FileBrowser(Viewer):
     """ """
 
-    path = param.ClassSelector(Path, precedence=-1)
+    path = param.ClassSelector(class_=Path, precedence=-1)
     path_text = param.String(label="", precedence=0.3)
     home = param.Action(lambda self: self.go_home(), label="🏠", precedence=0.1)
     up = param.Action(lambda self: self.move_up(), label="⬆️", precedence=0.2)
@@ -613,11 +613,11 @@ class AsyncHpcPath(HpcPath):
 
 
 class HpcFileBrowser(FileBrowser):
-    path = param.ClassSelector(HpcPath)
+    path = param.ClassSelector(class_=HpcPath)
     workdir = param.Action(
         lambda self: self.go_to_workdir(), label="⚙️", precedence=0.15
     )
-    uit_client = param.ClassSelector(Client)
+    uit_client = param.ClassSelector(class_=Client)
 
     def __init__(self, uit_client, **params):
         params["uit_client"] = uit_client
@@ -648,7 +648,7 @@ class HpcFileBrowser(FileBrowser):
 
 
 class AsyncHpcFileBrowser(HpcFileBrowser):
-    uit_client = param.ClassSelector(AsyncClient)
+    uit_client = param.ClassSelector(class_=AsyncClient)
 
     def __init__(self, uit_client, **params):
         super().__init__(uit_client, **params)
@@ -720,7 +720,7 @@ class FileSelector(Viewer):
     file_path = param.String(default="")
     show_browser = param.Boolean(default=False)
     browse_toggle = param.Action(lambda self: self.toggle(), label="Browse")
-    file_browser = param.ClassSelector(FileBrowser)
+    file_browser = param.ClassSelector(class_=FileBrowser)
     title = param.String(default="File Path")
     help_text = param.String()
     disabled = param.Boolean(precedence=-1)
@@ -826,10 +826,10 @@ class FileViewer(Viewer):
         precedence=-4,
         doc="Maximum line length. Lines logger than specified length will be broken up.",
     )
-    file_select = param.ClassSelector(FileSelector)
+    file_select = param.ClassSelector(class_=FileSelector)
     file_path = param.String()
     file_contents = param.String()
-    uit_client = param.ClassSelector(Client)
+    uit_client = param.ClassSelector(class_=Client)
     grep_pattern = param.String(label="Search", precedence=-1)
     grep_context = param.Integer(label="Context Lines", default=4, precedence=-1)
     grep_ignore_case = param.Boolean(label="Ignore Case", precedence=-1)
@@ -970,7 +970,7 @@ class FileViewer(Viewer):
 
 
 class AsyncFileViewer(FileViewer):
-    uit_client = param.ClassSelector(AsyncClient)
+    uit_client = param.ClassSelector(class_=AsyncClient)
     file_browser_class = AsyncHpcFileBrowser
 
     @param.depends("update_btn", watch=True)

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -211,9 +211,9 @@ class PbsScriptAdvancedInputs(HpcConfigurable):
     env_values = param.List()
     env_browsers = param.List()
     env_delete_buttons = param.List()
-    file_browser = param.ClassSelector(HpcFileBrowser)
+    file_browser = param.ClassSelector(class_=HpcFileBrowser)
     file_browser_col = param.ClassSelector(
-        pn.Column, default=pn.Column(None, sizing_mode="stretch_width")
+        class_=pn.Column, default=pn.Column(None, sizing_mode="stretch_width")
     )
     apply_file_browser = param.Action(label="Apply")
     close_file_browser = param.Action(
@@ -397,12 +397,12 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
     validated = param.Boolean()
     job_name = param.String(label="Job Name (Required, cannot contain spaces or tabs)")
     error_messages = param.ClassSelector(
-        pn.Column, default=pn.Column(sizing_mode="stretch_width")
+        class_=pn.Column, default=pn.Column(sizing_mode="stretch_width")
     )
-    _job = param.ClassSelector(PbsJob, default=None)
+    _job = param.ClassSelector(class_=PbsJob, default=None)
     ready = param.Boolean(default=False, precedence=-1)
     next_stage = param.Selector()
-    pipeline_obj = param.ClassSelector(pn.pipeline.Pipeline)
+    pipeline_obj = param.ClassSelector(class_=pn.pipeline.Pipeline)
 
     # TODO should this be here?  (see line 324)
     user_workspace = None

--- a/uit/gui_tools/utils.py
+++ b/uit/gui_tools/utils.py
@@ -30,7 +30,7 @@ async def await_if_async(result):
 
 
 class HpcBase(param.Parameterized):
-    uit_client = param.ClassSelector(Client)
+    uit_client = param.ClassSelector(class_=Client)
 
     @property
     def await_if_async(self):
@@ -39,7 +39,7 @@ class HpcBase(param.Parameterized):
 
 class HpcConfigurable(HpcBase):
     configuration_file = param.String()
-    environment_variables = param.ClassSelector(OrderedDict, default=OrderedDict())
+    environment_variables = param.ClassSelector(class_=OrderedDict, default=OrderedDict())
     modules_to_load = param.ListSelector(default=[])
     modules_to_unload = param.ListSelector(default=[])
 
@@ -118,8 +118,8 @@ class HpcConfigurable(HpcBase):
 
 
 class HpcWorkspaces(HpcConfigurable):
-    working_dir = param.ClassSelector(PurePosixPath)
-    _user_workspace = param.ClassSelector(Path)
+    working_dir = param.ClassSelector(class_=PurePosixPath)
+    _user_workspace = param.ClassSelector(class_=Path)
 
     @property
     def remote_workspace_suffix(self):
@@ -235,7 +235,7 @@ class PbsJobTabbedViewer(HpcWorkspaces):
 
 class TabView(param.Parameterized):
     title = param.String()
-    parent = param.ClassSelector(PbsJobTabbedViewer)
+    parent = param.ClassSelector(class_=PbsJobTabbedViewer)
 
     def __str__(self):
         return f"<{self.__class__.__name__}: {self.title} parent={self.parent}"
@@ -372,7 +372,7 @@ class LogsTab(TabView):
 
 class FileViewerTab(TabView):
     title = param.String(default="Files")
-    file_viewer = param.ClassSelector(FileViewer)
+    file_viewer = param.ClassSelector(class_=FileViewer)
 
     def __init__(self, **params):
         super().__init__(**params)


### PR DESCRIPTION
Param 2.0 does not want any positional arguments for ClassSelector. https://param.holoviz.org/upgrade_guide.html#deprecations

This PR addresses these deprecation warnings: `ParamFutureWarning: Passing 'class_' as positional argument(s) to 'param.ClassSelector' has been deprecated since Param 2.0.0 and will raise an error in a future version, please pass them as keyword arguments.`

CHW-664