### PR TITLE
Fix submit stage file browser

### DIFF
--- a/uit/gui_tools/__init__.py
+++ b/uit/gui_tools/__init__.py
@@ -16,6 +16,7 @@ from .utils import (
 )
 from .file_browser import (
     get_js_loading_code,
+    create_file_browser,
     FileBrowser,
     FileManager,
     FileManagerHPC,

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -683,6 +683,13 @@ class AsyncHpcFileBrowser(HpcFileBrowser):
         self.do_callback()
 
 
+def create_file_browser(uit_client, **kwargs):
+    if isinstance(uit_client, AsyncClient):
+        return AsyncHpcFileBrowser(uit_client, **kwargs)
+    if isinstance(self.uit_client, Client):
+        return HpcFileBrowser(uit_client, **kwargs)
+
+
 class FileSelector(Viewer):
     file_path = param.String(default="")
     show_browser = param.Boolean(default=False)

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -705,7 +705,7 @@ class FileSelector(Viewer):
         self.file_browser = self.file_browser or FileBrowser(delayed_init=True)
         self.update_file(True)
         self.disabled = disabled
-        # self.param.file_path.label = self.title
+        self.param.file_path.label = self.title
         self._layout = pn.Column(
             self.input_row,
             pn.pane.HTML(f'<span style="font-style: italic;">{self.help_text}</span>'),

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -686,7 +686,7 @@ class AsyncHpcFileBrowser(HpcFileBrowser):
 def create_file_browser(uit_client, **kwargs):
     if isinstance(uit_client, AsyncClient):
         return AsyncHpcFileBrowser(uit_client, **kwargs)
-    if isinstance(self.uit_client, Client):
+    if isinstance(uit_client, Client):
         return HpcFileBrowser(uit_client, **kwargs)
 
 

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -4,36 +4,43 @@ from functools import partial
 from itertools import zip_longest
 
 from bokeh.models import NumberFormatter
-from bokeh.models.widgets.tables import SelectEditor
 import param
 import panel as pn
 
-from .file_browser import HpcFileBrowser, create_file_browser, get_js_loading_code,FileSelector
+from .file_browser import HpcFileBrowser, create_file_browser, get_js_loading_code, FileSelector
 from .utils import HpcBase, HpcConfigurable
 from ..uit import QUEUES
 from ..pbs_script import NODE_TYPES, factors, PbsScript
 from ..job import PbsJob
 
 
-
 logger = logging.getLogger(__name__)
 
 
 class PbsScriptInputs(HpcBase):
-    hpc_subproject = param.Selector(default=None, label="HPC Subproject", precedence=3, doc='Allocation to charge for this job')
-    subproject_usage = param.DataFrame(precedence=3.1,doc='Information about this allocation')
-    #workdir = param.String(default="", precedence=4,doc='Base directory for full experiment')
-    node_type = param.Selector(default="", objects=[], label="Node Type", precedence=5, doc='Type of node on which job will be run.')
-    nodes = param.Integer(default=1, bounds=(1, 1000), precedence=5.1,doc='Nodes to request per each sub-job.')
-    processes_per_node = param.Selector(default=1, objects=[], label="Processes per Node", precedence=5.2,doc='Processors per node to use.')
-    wall_time = param.String(default="01:00:00", label="Wall Time", precedence=6, doc='Walltime to request for each sub-job.')
+    hpc_subproject = param.Selector(
+        default=None, label="HPC Subproject", precedence=3, doc="Allocation to charge for this job"
+    )
+    subproject_usage = param.DataFrame(precedence=3.1, doc="Information about this allocation")
+    node_type = param.Selector(
+        default="", objects=[], label="Node Type", precedence=5, doc="Type of node on which job will be run."
+    )
+    nodes = param.Integer(default=1, bounds=(1, 1000), precedence=5.1, doc="Nodes to request per each sub-job.")
+    processes_per_node = param.Selector(
+        default=1, objects=[], label="Processes per Node", precedence=5.2, doc="Processors per node to use."
+    )
+    wall_time = param.String(
+        default="01:00:00", label="Wall Time", precedence=6, doc="Walltime to request for each sub-job."
+    )
     wall_time_alert = pn.pane.Alert(visible=False)
     node_alert = pn.pane.Alert(visible=False)
-    queue = param.Selector(default=QUEUES[0], objects=QUEUES, precedence=7, doc='Scheduling queue to use for this job.')
+    queue = param.Selector(default=QUEUES[0], objects=QUEUES, precedence=7, doc="Scheduling queue to use for this job.")
     max_wall_time = param.String(default="Not Found", label="Max Wall Time", precedence=7.1)
     max_nodes = param.String(default="Not Found", label="Max Processes", precedence=7.2)
     submit_script_filename = param.String(default="run.pbs", precedence=8)
-    notification_email = param.String(label="Notification E-mail(s)", precedence=9,doc='Set up email notification(s) for job start and/or finish.')
+    notification_email = param.String(
+        label="Notification E-mail(s)", precedence=9, doc="Set up email notification(s) for job start and/or finish."
+    )
     notify_start = param.Boolean(default=True, label="when job begins", precedence=9.1)
     notify_end = param.Boolean(default=True, label="when job ends", precedence=9.2)
 
@@ -42,17 +49,13 @@ class PbsScriptInputs(HpcBase):
     wall_time_maxes = None
     node_maxes = None
 
-
     def __init__(self, **params):
         super().__init__(**params)
         self.workdir = FileSelector(
-            title = 'Working Directory',
-            help_text='Base directory for full experiment',
-            show_browser=False
+            title="Working Directory", help_text="Base directory for full experiment", show_browser=False
         )
 
-
-    @param.depends ('uit_client',watch=True)
+    @param.depends("uit_client", watch=True)
     def set_file_browser(self):
         self.workdir.file_browser = create_file_browser(self.uit_client, patterns=[])
 

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -52,7 +52,7 @@ class PbsScriptInputs(HpcBase):
     def __init__(self, **params):
         super().__init__(**params)
         self.workdir = FileSelector(
-            title="Working Directory", help_text="Base directory for full experiment", show_browser=False
+            title="Base Directory", help_text="Base directory for full experiment", show_browser=False
         )
 
     @param.depends("uit_client", watch=True)
@@ -485,14 +485,13 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
 
     @property
     def job(self):
-        print('setting up job.  working directory is:')
-        print(self.workdir.file_path)
+
         if self._job is None:
             self._job = PbsJob(
                 script=self.pbs_script,
                 client=self.uit_client,
                 workspace=self.user_workspace,
-                working_dir=self.workdir.file_path,
+                base_dir=self.workdir.file_path,
             )
         return self._job
 

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -4,33 +4,36 @@ from functools import partial
 from itertools import zip_longest
 
 from bokeh.models import NumberFormatter
+from bokeh.models.widgets.tables import SelectEditor
 import param
 import panel as pn
 
-from .file_browser import HpcFileBrowser, create_file_browser, get_js_loading_code
+from .file_browser import HpcFileBrowser, create_file_browser, get_js_loading_code,FileSelector
 from .utils import HpcBase, HpcConfigurable
 from ..uit import QUEUES
 from ..pbs_script import NODE_TYPES, factors, PbsScript
 from ..job import PbsJob
 
+
+
 logger = logging.getLogger(__name__)
 
 
 class PbsScriptInputs(HpcBase):
-    hpc_subproject = param.Selector(default=None, label="HPC Subproject", precedence=3)
-    subproject_usage = param.DataFrame(precedence=3.1)
-    workdir = param.String(default="", precedence=4)
-    node_type = param.Selector(default="", objects=[], label="Node Type", precedence=5)
-    nodes = param.Integer(default=1, bounds=(1, 1000), precedence=5.1)
-    processes_per_node = param.Selector(default=1, objects=[], label="Processes per Node", precedence=5.2)
-    wall_time = param.String(default="01:00:00", label="Wall Time", precedence=6)
+    hpc_subproject = param.Selector(default=None, label="HPC Subproject", precedence=3, doc='Allocation to charge for this job')
+    subproject_usage = param.DataFrame(precedence=3.1,doc='Information about this allocation')
+    #workdir = param.String(default="", precedence=4,doc='Base directory for full experiment')
+    node_type = param.Selector(default="", objects=[], label="Node Type", precedence=5, doc='Type of node on which job will be run.')
+    nodes = param.Integer(default=1, bounds=(1, 1000), precedence=5.1,doc='Nodes to request per each sub-job.')
+    processes_per_node = param.Selector(default=1, objects=[], label="Processes per Node", precedence=5.2,doc='Processors per node to use.')
+    wall_time = param.String(default="01:00:00", label="Wall Time", precedence=6, doc='Walltime to request for each sub-job.')
     wall_time_alert = pn.pane.Alert(visible=False)
     node_alert = pn.pane.Alert(visible=False)
-    queue = param.Selector(default=QUEUES[0], objects=QUEUES, precedence=7)
+    queue = param.Selector(default=QUEUES[0], objects=QUEUES, precedence=7, doc='Scheduling queue to use for this job.')
     max_wall_time = param.String(default="Not Found", label="Max Wall Time", precedence=7.1)
     max_nodes = param.String(default="Not Found", label="Max Processes", precedence=7.2)
     submit_script_filename = param.String(default="run.pbs", precedence=8)
-    notification_email = param.String(label="Notification E-mail(s)", precedence=9)
+    notification_email = param.String(label="Notification E-mail(s)", precedence=9,doc='Set up email notification(s) for job start and/or finish.')
     notify_start = param.Boolean(default=True, label="when job begins", precedence=9.1)
     notify_end = param.Boolean(default=True, label="when job ends", precedence=9.2)
 
@@ -38,6 +41,20 @@ class PbsScriptInputs(HpcBase):
     DEFAULT_PROCESSES_PER_JOB = 500
     wall_time_maxes = None
     node_maxes = None
+
+
+    def __init__(self, **params):
+        super().__init__(**params)
+        self.workdir = FileSelector(
+            title = 'Working Directory',
+            help_text='Base directory for full experiment',
+            show_browser=False
+        )
+
+
+    @param.depends ('uit_client',watch=True)
+    def set_file_browser(self):
+        self.workdir.file_browser = create_file_browser(self.uit_client, patterns=[])
 
     @staticmethod
     def get_default(value, objects):
@@ -54,7 +71,7 @@ class PbsScriptInputs(HpcBase):
         subprojects = self.subproject_usage["Subproject"].to_list()
         self.param.hpc_subproject.objects = subprojects
         self.hpc_subproject = self.get_default(self.hpc_subproject, subprojects)
-        self.workdir = self.uit_client.WORKDIR.as_posix()
+        self.workdir.file_path = self.uit_client.WORKDIR.as_posix()
         self.param.node_type.objects = list(NODE_TYPES[self.uit_client.system].keys())
         self.node_type = self.get_default(self.node_type, self.param.node_type.objects)
         self.param.queue.objects = await self.await_if_async(self.uit_client.get_queues())
@@ -169,7 +186,7 @@ class PbsScriptInputs(HpcBase):
             ),
             pn.Column(
                 self.param.hpc_subproject,
-                self.param.workdir,
+                self.workdir,
                 self.param.node_type,
                 pn.widgets.Spinner.from_param(self.param.nodes),
                 self.param.processes_per_node,
@@ -470,6 +487,7 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
                 script=self.pbs_script,
                 client=self.uit_client,
                 workspace=self.user_workspace,
+                working_dir=self.workdir.file_path,
             )
         return self._job
 

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -19,27 +19,52 @@ logger = logging.getLogger(__name__)
 
 class PbsScriptInputs(HpcBase):
     hpc_subproject = param.Selector(
-        default=None, label="HPC Subproject", precedence=3, doc="Allocation to charge for this job"
+        default=None,
+        label="HPC Subproject",
+        precedence=3,
+        doc="The resource allocation code that will be used when submitting this job.",
     )
-    subproject_usage = param.DataFrame(precedence=3.1, doc="Information about this allocation")
+    subproject_usage = param.DataFrame(precedence=3.1, doc="Usage details about your available subproject allocations.")
     node_type = param.Selector(
-        default="", objects=[], label="Node Type", precedence=5, doc="Type of node on which job will be run."
+        default="", objects=[], label="Node Type", precedence=5, doc="Type of node on which this job will be run."
     )
-    nodes = param.Integer(default=1, bounds=(1, 1000), precedence=5.1, doc="Nodes to request per each sub-job.")
+    nodes = param.Integer(
+        default=1,
+        bounds=(1, 1000),
+        precedence=5.1,
+        doc=(
+            "Number of nodes to request for the job.\n\n"
+            "**Note:** for array jobs, the number of nodes requested are available to each sub job."
+        ),
+    )
     processes_per_node = param.Selector(
-        default=1, objects=[], label="Processes per Node", precedence=5.2, doc="Processors per node to use."
+        default=1,
+        objects=[],
+        label="Processes per Node",
+        precedence=5.2,
+        doc="Number of processes per node to request for the job.",
     )
     wall_time = param.String(
-        default="01:00:00", label="Wall Time", precedence=6, doc="Walltime to request for each sub-job."
+        default="01:00:00",
+        label="Wall Time (HH:MM:SS)",
+        precedence=6,
+        doc=(
+            "Maximum allowable time for the job to run.\n\n"
+            "**Note:** for array jobs, the entire amount of wall time requested is available to each sub job."
+        ),
     )
     wall_time_alert = pn.pane.Alert(visible=False)
     node_alert = pn.pane.Alert(visible=False)
-    queue = param.Selector(default=QUEUES[0], objects=QUEUES, precedence=7, doc="Scheduling queue to use for this job.")
+    queue = param.Selector(
+        default=QUEUES[0], objects=QUEUES, precedence=7, doc="Scheduling queue to which the job will be submitted."
+    )
     max_wall_time = param.String(default="Not Found", label="Max Wall Time", precedence=7.1)
     max_nodes = param.String(default="Not Found", label="Max Processes", precedence=7.2)
     submit_script_filename = param.String(default="run.pbs", precedence=8)
     notification_email = param.String(
-        label="Notification E-mail(s)", precedence=9, doc="Set up email notification(s) for job start and/or finish."
+        label="Notification E-mail(s)",
+        precedence=9,
+        doc="E-mail address to receive notification(s) when the job starts and/or ends.",
     )
     notify_start = param.Boolean(default=True, label="when job begins", precedence=9.1)
     notify_end = param.Boolean(default=True, label="when job ends", precedence=9.2)
@@ -52,7 +77,13 @@ class PbsScriptInputs(HpcBase):
     def __init__(self, **params):
         super().__init__(**params)
         self.workdir = FileSelector(
-            title="Base Directory", help_text="Base directory for full experiment", show_browser=False
+            title="Base Directory",
+            show_browser=False,
+            help_text=(
+                "Base directory that the job's working directory path will be created in.\n\n"
+                "**Note:** by default the job's working directory is: "
+                f"`<BASE_DIRECTORY>/{PbsJob.DEFAULT_JOB_LABEL}/<JOB_NAME>.<TIMESTAMP>/`"
+            ),
         )
 
     @param.depends("uit_client", watch=True)

--- a/uit/gui_tools/submit.py
+++ b/uit/gui_tools/submit.py
@@ -485,6 +485,8 @@ class HpcSubmit(PbsScriptInputs, PbsScriptAdvancedInputs):
 
     @property
     def job(self):
+        print('setting up job.  working directory is:')
+        print(self.workdir.file_path)
         if self._job is None:
             self._job = PbsJob(
                 script=self.pbs_script,

--- a/uit/gui_tools/utils.py
+++ b/uit/gui_tools/utils.py
@@ -102,15 +102,13 @@ class HpcConfigurable(HpcBase):
 
 
 class HpcWorkspaces(HpcConfigurable):
-    working_dir = param.ClassSelector(class_=PurePosixPath)
+    base_dir = param.ClassSelector(class_=PurePosixPath)
+    remote_workspace_suffix = param.ClassSelector(class_=PurePosixPath)
     _user_workspace = param.ClassSelector(class_=Path)
 
     @property
-    def remote_workspace_suffix(self):
-        try:
-            return self.working_dir.relative_to(self.uit_client.WORKDIR)
-        except ValueError:
-            return self.working_dir.relative_to("/p")
+    def working_dir(self):
+        return self.base_dir / self.remote_workspace_suffix
 
     @property
     def workspace(self):
@@ -188,7 +186,8 @@ class PbsJobTabbedViewer(HpcWorkspaces):
 
     def update_working_dir(self):
         if self.selected_job is not None:
-            self.working_dir = self.selected_job.working_dir
+            self.base_dir = self.selected_job.base_dir
+            self.remote_workspace_suffix = self.selected_job.remote_workspace_suffix
 
     @param.depends("selected_sub_job", watch=True)
     def update_active_job(self):

--- a/uit/job.py
+++ b/uit/job.py
@@ -26,7 +26,7 @@ class PbsJob:
         transfer_input_files=None,
         home_input_files=None,
         archive_input_files=None,
-        working_dir=None,
+        base_dir=None,
         description=None,
         metadata=None,
         post_processing_script=None,
@@ -43,20 +43,14 @@ class PbsJob:
         self.metadata = metadata or dict()
         self.label = label
         self.cleanup = False
-        self._working_dir = working_dir
+        self._base_dir = PurePosixPath(base_dir) if base_dir is not None else None
+        self._working_dir = None
         self._job_id = None
         self._status = None
         self._qstat = None
         self._post_processing_job_id = None
         self._remote_workspace_id = None
         self._remote_workspace = None
-
-        print('In PBSJob.  Client is:')
-        print(self.client)
-        print('My working directory is:')
-        print(self._working_dir)
-        print('My ID is')
-        print(self._job_id)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} name={self.name} id={self.job_id}>"
@@ -84,11 +78,15 @@ class PbsJob:
         return self.script.name
 
     @property
+    def base_dir(self):
+        if self._base_dir is None:
+            self._base_dir = self.client.WORKDIR
+        return self._base_dir
+
+    @property
     def working_dir(self):
-        if self._working_dir == self.client.WORKDIR:
-            self._working_dir = self.client.WORKDIR / self.remote_workspace_suffix
-        elif self._working_dir.name != self.remote_workspace_suffix.name:
-            self._working_dir = self._working_dir / self.remote_workspace_suffix.name
+        if self._working_dir is None:
+            self._working_dir = self.base_dir / self.remote_workspace_suffix
         return self._working_dir
 
     @property
@@ -515,7 +513,7 @@ class PbsArrayJob(PbsJob):
                 parent.client,
                 parent.label,
                 parent.workspace,
-                working_dir=parent.working_dir,
+                base_dir=parent.base_dir,
             )
             self.parent = parent
             self._remote_workspace_id = self.parent._remote_workspace_id

--- a/uit/job.py
+++ b/uit/job.py
@@ -51,6 +51,13 @@ class PbsJob:
         self._remote_workspace_id = None
         self._remote_workspace = None
 
+        print('In PBSJob.  Client is:')
+        print(self.client)
+        print('My working directory is:')
+        print(self._working_dir)
+        print('My ID is')
+        print(self._job_id)
+
     def __repr__(self):
         return f"<{self.__class__.__name__} name={self.name} id={self.job_id}>"
 
@@ -78,8 +85,10 @@ class PbsJob:
 
     @property
     def working_dir(self):
-        if self._working_dir is None:
+        if self._working_dir == self.client.WORKDIR:
             self._working_dir = self.client.WORKDIR / self.remote_workspace_suffix
+        elif self._working_dir.name != self.remote_workspace_suffix.name:
+            self._working_dir = self._working_dir / self.remote_workspace_suffix.name
         return self._working_dir
 
     @property

--- a/uit/job.py
+++ b/uit/job.py
@@ -16,12 +16,13 @@ logger = logging.getLogger(__name__)
 
 
 class PbsJob:
+    DEFAULT_JOB_LABEL = "pyuit"
 
     def __init__(
         self,
         script,
         client=None,
-        label="pyuit",
+        label=DEFAULT_JOB_LABEL,
         workspace=None,
         transfer_input_files=None,
         home_input_files=None,


### PR DESCRIPTION
Changes the advanced options view of the submit stage dynamically create either  an `HpcFileBrowser` or an `AsyncHpcFileBrowser` object depending on the type of `uit_client`. 

Also updated the dynamic hiding and showing of the file browser to play better with Panel 1.x