### PR TITLE
Fix empty file list and loading spinner in sync file browser

### DIFF
--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -286,10 +286,12 @@ class FileBrowser(Viewer):
     def go_home(self):
         self.path_text = Path.cwd().as_posix()
         self.file_listing = []
+        self.stop_loading()
 
     def move_up(self):
         self.path_text = self.path.parent.as_posix()
         self.file_listing = []
+        self.stop_loading()
 
     @param.depends("file_listing", watch=True)
     def move_down(self):
@@ -297,6 +299,7 @@ class FileBrowser(Viewer):
             filename = self.file_listing[0]
             fn = self.path / filename
             self.path_text = fn.as_posix()
+            self.stop_loading()
 
     @param.depends("path_text", "refresh_control", watch=True)
     def validate(self):
@@ -618,11 +621,13 @@ class HpcFileBrowser(FileBrowser):
     def go_home(self):
         self.path_text = self._new_path(self.uit_client.HOME).as_posix()
         self.file_listing = []
+        self.stop_loading()
 
     @HpcPath._ensure_connected
     def go_to_workdir(self):
         self.path_text = self._new_path(self.uit_client.WORKDIR).as_posix()
         self.file_listing = []
+        self.stop_loading()
 
 
 class AsyncHpcFileBrowser(HpcFileBrowser):

--- a/uit/gui_tools/file_browser.py
+++ b/uit/gui_tools/file_browser.py
@@ -599,6 +599,7 @@ class HpcFileBrowser(FileBrowser):
     def __init__(self, uit_client, **params):
         params["uit_client"] = uit_client
         super().__init__(**params)
+        self.param.trigger("uit_client")  # for _initialize_path()
 
     @property
     def controls(self):


### PR DESCRIPTION
This change addresses a couple of bugs with HpcFileBrowser:

- The file browser widget would start with a blank directory and empty file list. I found that _initialize_path() was not getting called, so I added a param trigger on "uit_client".
- The file browser then forever displayed the loading spinner after switching directories, and it blocked mouse input. I added several self.stop_loading() calls to functions like go_home() and move_up(). Those used to call self.do_callback() in a previous revision, but using that now caused another log message of being unable to open a file.

CHW-681